### PR TITLE
fix: update AtB status valid color

### DIFF
--- a/packages/theme/src/themes/atb-theme/theme.css
+++ b/packages/theme/src/themes/atb-theme/theme.css
@@ -66,7 +66,7 @@
   --colors-transport_other-backgroundColor: #555E65;
   --colors-transport_other-color: #FFFFFF;
 
-  --status-valid-main-backgroundColor: #757D00;
+  --status-valid-main-backgroundColor: #A2AD00;
   --status-valid-main-color: #000000;
   --status-info-main-backgroundColor: #71D6E0;
   --status-info-main-color: #000000;

--- a/packages/theme/src/themes/atb-theme/theme.module.css
+++ b/packages/theme/src/themes/atb-theme/theme.module.css
@@ -66,7 +66,7 @@
   --colors-transport_other-backgroundColor: #555E65;
   --colors-transport_other-color: #FFFFFF;
 
-  --status-valid-main-backgroundColor: #757D00;
+  --status-valid-main-backgroundColor: #A2AD00;
   --status-valid-main-color: #000000;
   --status-info-main-backgroundColor: #71D6E0;
   --status-info-main-color: #000000;

--- a/packages/theme/src/themes/atb-theme/theme.ts
+++ b/packages/theme/src/themes/atb-theme/theme.ts
@@ -128,7 +128,7 @@ const themes: Themes = {
 
     status: {
       valid: {
-        main: contrastColor(colors.primary.green_500, 'dark'),
+        main: contrastColor(colors.primary.green_300, 'dark'),
       },
       info: {
         main: contrastColor(colors.secondary.cyan_200, 'dark'),


### PR DESCRIPTION
Oppdaget at feil grønnfarge ble brukt for valid status etter #12, som nå er oppdatert til å matche Figma

## Før/etter

![Screenshot 2021-12-06 at 12 50 52](https://user-images.githubusercontent.com/1774972/144841322-6876c152-59e1-4de8-b712-48b7c2293bac.png)
![Screenshot 2021-12-06 at 12 51 20](https://user-images.githubusercontent.com/1774972/144841336-93cd1e6f-54b4-43ca-b530-07ae6ad7b377.png)


