### PR TITLE
feat: add label__uppercase text style

### DIFF
--- a/packages/theme/src/typography.css
+++ b/packages/theme/src/typography.css
@@ -73,6 +73,11 @@
   --baseTypo-heading__paragraph-letterSpacing: 0.03125rem;
   --baseTypo-heading__paragraph-fontWeight: 500;
 
+  /* Definitions for label__uppercase */
+  --baseTypo-label__uppercase-fontSize: 0.5rem;
+  --baseTypo-label__uppercase-lineHeight: 1rem;
+  --baseTypo-label__uppercase-textTransform: uppercase;
+
 
   /* Included font types */
   --font-main: 'Roboto', sans-serif;
@@ -153,4 +158,9 @@ html {
   line-height: var(--baseTypo-heading__paragraph-lineHeight, 1.25rem);
   letter-spacing: var(--baseTypo-heading__paragraph-letterSpacing, 0.03125rem);
   font-weight: var(--baseTypo-heading__paragraph-fontWeight, 500);
+}
+.typo-label__uppercase {
+  font-size: var(--baseTypo-label__uppercase-fontSize, 0.5rem);
+  line-height: var(--baseTypo-label__uppercase-lineHeight, 1rem);
+  text-transform: var(--baseTypo-label__uppercase-textTransform, uppercase);
 }

--- a/packages/theme/src/typography.module.css
+++ b/packages/theme/src/typography.module.css
@@ -73,6 +73,11 @@
   --baseTypo-heading__paragraph-letterSpacing: 0.03125rem;
   --baseTypo-heading__paragraph-fontWeight: 500;
 
+  /* Definitions for label__uppercase */
+  --baseTypo-label__uppercase-fontSize: 0.5rem;
+  --baseTypo-label__uppercase-lineHeight: 1rem;
+  --baseTypo-label__uppercase-textTransform: uppercase;
+
 
   /* Included font types */
   --font-main: 'Roboto', sans-serif;
@@ -153,4 +158,9 @@
   line-height: var(--baseTypo-heading__paragraph-lineHeight, 1.25rem);
   letter-spacing: var(--baseTypo-heading__paragraph-letterSpacing, 0.03125rem);
   font-weight: var(--baseTypo-heading__paragraph-fontWeight, 500);
+}
+.typo-label__uppercase {
+  font-size: var(--baseTypo-label__uppercase-fontSize, 0.5rem);
+  line-height: var(--baseTypo-label__uppercase-lineHeight, 1rem);
+  text-transform: var(--baseTypo-label__uppercase-textTransform, uppercase);
 }

--- a/packages/theme/src/typography/android.ts
+++ b/packages/theme/src/typography/android.ts
@@ -15,6 +15,11 @@ const tertiaryBase: TextStyle = {
   lineHeight: 16,
   letterSpacing: 0.4,
 };
+const labelBase: TextStyle = {
+  fontSize: 8,
+  lineHeight: 16,
+  letterSpacing: 0,
+};
 
 export const androidFontData: FontBook = {
   main: {
@@ -66,5 +71,9 @@ export const androidTextTypeStyles: TextTypeStyles = {
   heading__paragraph: {
     ...primaryBase,
     fontWeight: '500',
+  },
+  label__uppercase: {
+    ...labelBase,
+    textTransform: 'uppercase',
   },
 };

--- a/packages/theme/src/typography/ios.ts
+++ b/packages/theme/src/typography/ios.ts
@@ -15,6 +15,11 @@ const tertiaryBase: TextStyle = {
   lineHeight: 16,
   letterSpacing: 0,
 };
+const labelBase: TextStyle = {
+  fontSize: 8,
+  lineHeight: 16,
+  letterSpacing: 0,
+};
 
 export const iosFontData: FontBook = {
   main: {
@@ -64,5 +69,9 @@ export const iosTextTypeStyles: TextTypeStyles = {
   heading__paragraph: {
     ...primaryBase,
     fontWeight: '600',
+  },
+  label__uppercase: {
+    ...labelBase,
+    textTransform: 'uppercase',
   },
 };

--- a/packages/theme/src/typography/types.ts
+++ b/packages/theme/src/typography/types.ts
@@ -11,6 +11,7 @@ export const textNames = [
   'heading__title',
   'heading__component',
   'heading__paragraph',
+  'label__uppercase',
 ] as const;
 
 export type FontMetadata = {
@@ -45,6 +46,7 @@ export type TextStyle = {
     | '700'
     | '800'
     | '900';
+  textTransform?: 'uppercase' | 'lowercase' | 'capitalize' | 'none';
 };
 
 export type TextTypeStyles = {[key in TextNames]: TextStyle};

--- a/packages/theme/tools/create-typo.ts
+++ b/packages/theme/tools/create-typo.ts
@@ -117,6 +117,8 @@ function textStyleMapper(styleProp: ValidStyleProps) {
       return 'letter-spacing';
     case 'textDecorationLine':
       return 'text-decoration';
+    case 'textTransform':
+      return 'text-transform';
   }
 }
 function printTextStyleClasses(obj: TextTypeStyles) {

--- a/web/src/guide/index.tsx
+++ b/web/src/guide/index.tsx
@@ -200,6 +200,7 @@ function asCSSProperties(fontStyle: TextStyle): CSSProperties | undefined {
     lineHeight: `${fontStyle.lineHeight}px`,
     letterSpacing: `${fontStyle.letterSpacing}px`,
     textDecorationLine: fontStyle.textDecorationLine,
+    textTransform: fontStyle.textTransform,
     fontWeight: fontStyle.fontWeight as any,
   };
 }


### PR DESCRIPTION
Legger til ny tekst type "label__uppercase", som finnes i [Figma](https://www.figma.com/file/3rlcixpbhfBglNSctUkMys/Theme-1.0?node-id=26%3A2). Denne krevde også at `textTransform` skal kunne settes til `uppercase`, så legger til det som del av TextStyle-typen.

![Screenshot 2022-04-20 at 14 23 30](https://user-images.githubusercontent.com/1774972/164229795-9438af21-390a-44b7-a5f5-783c264f4c97.png)

Hadde en diskusjon med @hildeor om tekststørrelse og linehøyde er riktig, her tar vi muligens en ny runde og oppdaterer når vi får testet det i praksis.
