### PR TITLE
fix: adds missing accent 5 color

### DIFF
--- a/packages/assets/package.json
+++ b/packages/assets/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@atb-as/generate-assets",
-  "version": "4.0.0-alpha.5",
+  "version": "4.0.0-alpha.6",
   "private": false,
   "description": "OOS Design System generate-assets",
   "license": "EUPL-1.2",
@@ -27,7 +27,7 @@
     "access": "public"
   },
   "dependencies": {
-    "@atb-as/theme": "^6.0.0-alpha.2",
+    "@atb-as/theme": "^6.0.0-alpha.3",
     "commander": "^8.3.0",
     "fast-glob": "^3.2.7",
     "micromatch": "^4.0.4",

--- a/packages/theme/package.json
+++ b/packages/theme/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@atb-as/theme",
-  "version": "6.0.0-alpha.2",
+  "version": "6.0.0-alpha.3",
   "private": false,
   "description": "AtB Design System Colors",
   "license": "EUPL-1.2",

--- a/packages/theme/src/theme.ts
+++ b/packages/theme/src/theme.ts
@@ -47,6 +47,7 @@ export interface Theme {
       background_accent_2: ContrastColor;
       background_accent_3: ContrastColor;
       background_accent_4: ContrastColor;
+      background_accent_5: ContrastColor;
     };
 
     transport: {

--- a/packages/theme/src/themes/atb-theme/theme.css
+++ b/packages/theme/src/themes/atb-theme/theme.css
@@ -43,6 +43,8 @@
   --static-background-background_accent_3-text: #FFFFFF;
   --static-background-background_accent_4-background: #E5E8B8;
   --static-background-background_accent_4-text: #000000;
+  --static-background-background_accent_5-background: #A6D1D9;
+  --static-background-background_accent_5-text: #000000;
   --static-transport-transport_city-background: #A2AD00;
   --static-transport-transport_city-text: #000000;
   --static-transport-transport_region-background: #007C92;
@@ -162,6 +164,8 @@
   --static-background-background_accent_3-text: #FFFFFF;
   --static-background-background_accent_4-background: #E5E8B8;
   --static-background-background_accent_4-text: #000000;
+  --static-background-background_accent_5-background: #2B343A;
+  --static-background-background_accent_5-text: #FFFFFF;
   --static-transport-transport_city-background: #A2AD00;
   --static-transport-transport_city-text: #000000;
   --static-transport-transport_region-background: #007C92;
@@ -281,6 +285,8 @@
   --static-background-background_accent_3-text: #FFFFFF;
   --static-background-background_accent_4-background: #E5E8B8;
   --static-background-background_accent_4-text: #000000;
+  --static-background-background_accent_5-background: #2B343A;
+  --static-background-background_accent_5-text: #FFFFFF;
   --static-transport-transport_city-background: #A2AD00;
   --static-transport-transport_city-text: #000000;
   --static-transport-transport_region-background: #007C92;
@@ -394,6 +400,10 @@
 .static-background-background_accent_4 {
   background-color: var(--static-background-background_accent_4-background);
   color: var(--static-background-background_accent_4-text);
+}
+.static-background-background_accent_5 {
+  background-color: var(--static-background-background_accent_5-background);
+  color: var(--static-background-background_accent_5-text);
 }
 .static-transport-transport_city {
   background-color: var(--static-transport-transport_city-background);

--- a/packages/theme/src/themes/atb-theme/theme.module.css
+++ b/packages/theme/src/themes/atb-theme/theme.module.css
@@ -43,6 +43,8 @@
   --static-background-background_accent_3-text: #FFFFFF;
   --static-background-background_accent_4-background: #E5E8B8;
   --static-background-background_accent_4-text: #000000;
+  --static-background-background_accent_5-background: #A6D1D9;
+  --static-background-background_accent_5-text: #000000;
   --static-transport-transport_city-background: #A2AD00;
   --static-transport-transport_city-text: #000000;
   --static-transport-transport_region-background: #007C92;
@@ -162,6 +164,8 @@
   --static-background-background_accent_3-text: #FFFFFF;
   --static-background-background_accent_4-background: #E5E8B8;
   --static-background-background_accent_4-text: #000000;
+  --static-background-background_accent_5-background: #2B343A;
+  --static-background-background_accent_5-text: #FFFFFF;
   --static-transport-transport_city-background: #A2AD00;
   --static-transport-transport_city-text: #000000;
   --static-transport-transport_region-background: #007C92;
@@ -281,6 +285,8 @@
   --static-background-background_accent_3-text: #FFFFFF;
   --static-background-background_accent_4-background: #E5E8B8;
   --static-background-background_accent_4-text: #000000;
+  --static-background-background_accent_5-background: #2B343A;
+  --static-background-background_accent_5-text: #FFFFFF;
   --static-transport-transport_city-background: #A2AD00;
   --static-transport-transport_city-text: #000000;
   --static-transport-transport_region-background: #007C92;
@@ -394,6 +400,10 @@
 .static-background-background_accent_4 {
   background-color: var(--static-background-background_accent_4-background);
   color: var(--static-background-background_accent_4-text);
+}
+.static-background-background_accent_5 {
+  background-color: var(--static-background-background_accent_5-background);
+  color: var(--static-background-background_accent_5-text);
 }
 .static-transport-transport_city {
   background-color: var(--static-transport-transport_city-background);

--- a/packages/theme/src/themes/atb-theme/theme.ts
+++ b/packages/theme/src/themes/atb-theme/theme.ts
@@ -189,6 +189,7 @@ const themes: Themes = {
         background_accent_2: baseColors.blue_100,
         background_accent_3: baseColors.blue_500,
         background_accent_4: baseColors.green_100,
+        background_accent_5: baseColors.blue_200,
       },
       transport: {
         transport_city: baseColors.green_300,
@@ -276,6 +277,7 @@ const themes: Themes = {
         background_accent_2: baseColors.blue_100,
         background_accent_3: baseColors.blue_500,
         background_accent_4: baseColors.green_100,
+        background_accent_5: baseColors.gray_800,
       },
 
       transport: {

--- a/packages/theme/src/themes/nfk-theme/theme.css
+++ b/packages/theme/src/themes/nfk-theme/theme.css
@@ -43,6 +43,8 @@
   --static-background-background_accent_3-text: #003441;
   --static-background-background_accent_4-background: #FFFFFF;
   --static-background-background_accent_4-text: #003441;
+  --static-background-background_accent_5-background: #FFFFFF;
+  --static-background-background_accent_5-text: #003441;
   --static-transport-transport_city-background: #014D61;
   --static-transport-transport_city-text: #FFFFFF;
   --static-transport-transport_region-background: #6C7E2F;
@@ -162,6 +164,8 @@
   --static-background-background_accent_3-text: #FFFFFF;
   --static-background-background_accent_4-background: #000000;
   --static-background-background_accent_4-text: #FFFFFF;
+  --static-background-background_accent_5-background: #000000;
+  --static-background-background_accent_5-text: #FFFFFF;
   --static-transport-transport_city-background: #80C0D1;
   --static-transport-transport_city-text: #003441;
   --static-transport-transport_region-background: #98A56D;
@@ -281,6 +285,8 @@
   --static-background-background_accent_3-text: #FFFFFF;
   --static-background-background_accent_4-background: #000000;
   --static-background-background_accent_4-text: #FFFFFF;
+  --static-background-background_accent_5-background: #000000;
+  --static-background-background_accent_5-text: #FFFFFF;
   --static-transport-transport_city-background: #80C0D1;
   --static-transport-transport_city-text: #003441;
   --static-transport-transport_region-background: #98A56D;
@@ -394,6 +400,10 @@
 .static-background-background_accent_4 {
   background-color: var(--static-background-background_accent_4-background);
   color: var(--static-background-background_accent_4-text);
+}
+.static-background-background_accent_5 {
+  background-color: var(--static-background-background_accent_5-background);
+  color: var(--static-background-background_accent_5-text);
 }
 .static-transport-transport_city {
   background-color: var(--static-transport-transport_city-background);

--- a/packages/theme/src/themes/nfk-theme/theme.module.css
+++ b/packages/theme/src/themes/nfk-theme/theme.module.css
@@ -43,6 +43,8 @@
   --static-background-background_accent_3-text: #003441;
   --static-background-background_accent_4-background: #FFFFFF;
   --static-background-background_accent_4-text: #003441;
+  --static-background-background_accent_5-background: #FFFFFF;
+  --static-background-background_accent_5-text: #003441;
   --static-transport-transport_city-background: #014D61;
   --static-transport-transport_city-text: #FFFFFF;
   --static-transport-transport_region-background: #6C7E2F;
@@ -162,6 +164,8 @@
   --static-background-background_accent_3-text: #FFFFFF;
   --static-background-background_accent_4-background: #000000;
   --static-background-background_accent_4-text: #FFFFFF;
+  --static-background-background_accent_5-background: #000000;
+  --static-background-background_accent_5-text: #FFFFFF;
   --static-transport-transport_city-background: #80C0D1;
   --static-transport-transport_city-text: #003441;
   --static-transport-transport_region-background: #98A56D;
@@ -281,6 +285,8 @@
   --static-background-background_accent_3-text: #FFFFFF;
   --static-background-background_accent_4-background: #000000;
   --static-background-background_accent_4-text: #FFFFFF;
+  --static-background-background_accent_5-background: #000000;
+  --static-background-background_accent_5-text: #FFFFFF;
   --static-transport-transport_city-background: #80C0D1;
   --static-transport-transport_city-text: #003441;
   --static-transport-transport_region-background: #98A56D;
@@ -394,6 +400,10 @@
 .static-background-background_accent_4 {
   background-color: var(--static-background-background_accent_4-background);
   color: var(--static-background-background_accent_4-text);
+}
+.static-background-background_accent_5 {
+  background-color: var(--static-background-background_accent_5-background);
+  color: var(--static-background-background_accent_5-text);
 }
 .static-transport-transport_city {
   background-color: var(--static-transport-transport_city-background);

--- a/packages/theme/src/themes/nfk-theme/theme.ts
+++ b/packages/theme/src/themes/nfk-theme/theme.ts
@@ -72,6 +72,7 @@ const themes: Themes = {
         background_accent_2: contrastColor('#FFFFFF', 'dark'),
         background_accent_3: contrastColor('#E6F2F6', 'dark'),
         background_accent_4: contrastColor('#FFFFFF', 'dark'),
+        background_accent_5: contrastColor('#FFFFFF', 'dark'),
       },
       transport: {
         transport_city: contrastColor('#014D61', 'light'),
@@ -158,6 +159,7 @@ const themes: Themes = {
         background_accent_2: contrastColor('#000000', 'light'),
         background_accent_3: contrastColor('#0181A2', 'light'),
         background_accent_4: contrastColor('#000000', 'light'),
+        background_accent_5: contrastColor('#000000', 'light'),
       },
       transport: {
         transport_city: contrastColor('#80C0D1'),


### PR DESCRIPTION
Adds missing static background accent 5 which is specified in the design system and used on the webshop (footer).


![Screenshot 2022-05-16 at 09 05 16](https://user-images.githubusercontent.com/606374/168537461-3ecede04-55cc-4ac2-bd53-1749388487fa.png)



cc @toretefre Should add for NFK after we find what colors it should be.