### PR TITLE
fix: update NFK LM_interactive_2_outline

### DIFF
--- a/packages/theme/src/themes/nfk-theme/theme.ts
+++ b/packages/theme/src/themes/nfk-theme/theme.ts
@@ -44,7 +44,7 @@ const themes: Themes = {
         hover: contrastColor('#0181A2', 'dark'),
         active: contrastColor('#99CDDA', 'dark'),
         disabled: contrastColor('#E6F2F6', 'dark'),
-        outline: contrastColor('#046073', 'light'),
+        outline: contrastColor('#00232C', 'light'),
       },
       interactive_3: {
         default: contrastColor('#FFFFFF', 'dark'),


### PR DESCRIPTION
Only used as ActiveTint-color in App TabNavigator (as seen in Reisesøk at bottom of picture)

<img width="411" alt="image" src="https://user-images.githubusercontent.com/21310942/168596100-0256311f-a70d-427a-add7-149c77d0ef44.png">
