### PR TITLE
add blank svg crash2 for nfk

### DIFF
--- a/packages/assets/files/nfk/colors/images/Crash2.svg
+++ b/packages/assets/files/nfk/colors/images/Crash2.svg
@@ -1,0 +1,1 @@
+<svg width="247" height="185" viewBox="0 0 247 185" fill="none" xmlns="http://www.w3.org/2000/svg" />


### PR DESCRIPTION
Since we need to have a corresponding svg file for NFK as well, adding a blank file. 