### PR TITLE
feat: adds generated icon types

### DIFF
--- a/packages/assets/package.json
+++ b/packages/assets/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@atb-as/generate-assets",
-  "version": "5.1.0-alpha.0",
+  "version": "5.1.0-alpha.1",
   "private": false,
   "description": "OOS Design System generate-assets",
   "license": "EUPL-1.2",

--- a/packages/assets/package.json
+++ b/packages/assets/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@atb-as/generate-assets",
-  "version": "5.0.0",
+  "version": "5.1.0-alpha.0",
   "private": false,
   "description": "OOS Design System generate-assets",
   "license": "EUPL-1.2",

--- a/packages/assets/package.json
+++ b/packages/assets/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@atb-as/generate-assets",
-  "version": "5.1.0-alpha.1",
+  "version": "5.1.0-alpha.2",
   "private": false,
   "description": "OOS Design System generate-assets",
   "license": "EUPL-1.2",

--- a/packages/assets/src/bin.ts
+++ b/packages/assets/src/bin.ts
@@ -2,17 +2,19 @@
 
 import {vaildOrgIds, generateAssets, searchGlob} from './generate';
 import pathlib from 'path';
-import {stringAsThemeVariant, themeVariantAsString} from './utils';
+import {AssetType, stringAsThemeVariant, themeVariantAsString} from './utils';
 import {setDebug} from './logger';
 
 import {program, Argument} from 'commander';
+import {generateTs} from './generateTs';
 
-type AssetType = 'colors' | 'all' | 'mono';
 type InputOptions = {
   debug: boolean;
   generateMonoTheme: boolean;
   glob?: string;
   outDir: string;
+  generateTs: boolean;
+  tsOutDir: string | undefined;
 };
 
 program
@@ -28,12 +30,17 @@ program
       .argRequired(),
   )
   .requiredOption('-o, --out-dir <output>', 'Output directory')
+  .option(
+    '-ts-o, --ts-out-dir <output>',
+    'Output directory for generated typescript',
+  )
   .option('-d, --debug', 'Log all files generated', false)
   .option(
     '-nm, --no-generate-mono-theme',
     'Ignore generating themed mono-icons, but keep general mono icons.',
     false,
   )
+  .option('-ts, --generate-ts', 'Generates typescript resolution file.', false)
   .option(
     '-g, --glob [glob]',
     'Pass in custom glob for matching files.',
@@ -76,6 +83,16 @@ const main = async () => {
       console.log(
         `Successfully written ${assets.length} assets for ${orgId} to ${outputFolder}`,
       );
+    }
+
+    if (opts.generateTs) {
+      const generatedTsFile = await generateTs(
+        assets,
+        assetType,
+        outputFolder,
+        opts.tsOutDir,
+      );
+      console.log(`Generated typescript file:  ${generatedTsFile}`);
     }
   } catch (e) {
     console.error((e as Error)?.message);

--- a/packages/assets/src/generateTs.ts
+++ b/packages/assets/src/generateTs.ts
@@ -4,6 +4,7 @@ import {AssetType} from './utils';
 
 type Data = Partial<{
   mono: Record<string, MonoType>;
+  colorIcons: Record<string, ColorType>;
   images: Record<string, ColorType>;
   illustration: Record<string, ColorType>;
 }>;
@@ -51,6 +52,7 @@ export type IconType = ColorType | MonoType;
 
 ${data.mono ? `export type MonoIcons = keyof Icons['mono'];` : ''}
 ${data.images ? `export type Images = keyof Icons['images'];` : ''}
+${data.colorIcons ? `export type ColorIcons = keyof Icons['colorIcons'];` : ''}
 ${
   data.illustration
     ? `export type Illustrations = keyof Icons['illustration'];`
@@ -81,6 +83,7 @@ function generateData(
   return {
     mono: mono ? toUniqueObject(mono) : undefined,
     images: colors?.images ? toUniqueObject(colors.images) : undefined,
+    colorIcons: colors?.icons ? toUniqueObject(colors.icons) : undefined,
     illustration: colors?.illustrations
       ? toUniqueObject(colors.illustrations)
       : undefined,
@@ -91,7 +94,7 @@ type ColorType = {
   relative: string;
   absolute: string;
   assetType: 'colors';
-  colorType: 'illustrations' | 'images';
+  colorType: 'illustrations' | 'images' | 'icons';
   darkable: boolean;
   id: string;
 };
@@ -127,7 +130,7 @@ function toTypeCoonstruct(
       relative,
       absolute,
       assetType: 'colors',
-      colorType: isIllustration(relative) ? 'illustrations' : 'images',
+      colorType: getColorType(relative),
       darkable: isDarkable(relative),
       id: toIDPath(relative),
     };
@@ -146,15 +149,26 @@ function toIDPath(relative: string) {
   return relative
     .replace(darkOrLight, '/')
     .replace(
-      /^\/?(?:(?:mono|colors)\/)?(?:(?:illustrations|images)\/)?(.*)\..{3}$/,
+      /^\/?(?:(?:mono|colors)\/)?(?:(?:illustrations|images|icons)\/)?(.*)\..{3}$/,
       '$1',
     );
 }
 function isDarkable(relative: string) {
   return relative.match(darkOrLight) !== null;
 }
-function isIllustration(relative: string) {
-  return relative.match(/^\/?(?:(?:mono|colors)\/)?illustrations\//) !== null;
+function getColorType(relative: string): ColorType['colorType'] {
+  const colorType = relative.match(
+    /^\/?(?:(?:mono|colors)\/)?(illustrations|images|icons)\//,
+  )?.[1];
+
+  switch (colorType) {
+    case 'illustrations':
+      return 'illustrations';
+    case 'icons':
+      return 'icons';
+    default:
+      return 'images';
+  }
 }
 
 const groupBy = <T, K extends keyof any>(list: T[], getKey: (item: T) => K) =>

--- a/packages/assets/src/generateTs.ts
+++ b/packages/assets/src/generateTs.ts
@@ -127,7 +127,7 @@ function toIDPath(relative: string) {
   return relative
     .replace(darkOrLight, '/')
     .replace(
-      /^\/(?:(?:mono|colors)\/)?(?:(?:illustrations|images)\/)?(.*)\..{3}$/,
+      /^\/?(?:(?:mono|colors)\/)?(?:(?:illustrations|images)\/)?(.*)\..{3}$/,
       '$1',
     );
 }
@@ -135,7 +135,7 @@ function isDarkable(relative: string) {
   return relative.match(darkOrLight) !== null;
 }
 function isIllustration(relative: string) {
-  return relative.match(/^\/(?:(?:mono|colors)\/)?illustrations\//) !== null;
+  return relative.match(/^\/?(?:(?:mono|colors)\/)?illustrations\//) !== null;
 }
 
 const groupBy = <T, K extends keyof any>(list: T[], getKey: (item: T) => K) =>

--- a/packages/assets/src/generateTs.ts
+++ b/packages/assets/src/generateTs.ts
@@ -1,0 +1,155 @@
+import fs from 'fs/promises';
+import path from 'path';
+import {AssetType} from './utils';
+
+type Data = Partial<{
+  mono: Record<string, MonoTypeConstruct>;
+  images: Record<string, ColorsTypeConstruct>;
+  illustration: Record<string, ColorsTypeConstruct>;
+}>;
+export async function generateTs(
+  allFiles: string[],
+  assetTypeInput: AssetType,
+  outputDir: string,
+  tsOutput: string = outputDir,
+) {
+  const data = generateData(allFiles, assetTypeInput, outputDir);
+  const generatedContents = template(data);
+
+  await fs.mkdir(tsOutput, {recursive: true});
+  const destinationFile = path.join(tsOutput, 'generated-icons.ts');
+  await fs.writeFile(destinationFile, generatedContents);
+
+  return destinationFile;
+}
+
+function template(data: Data) {
+  return `// NB! NB! NB!
+// AUTO GENERATED FILE. DON'T CHANGE
+// NB! NB! NB!
+export const icons = ${JSON.stringify(data, null, 2)};
+export type Icons = typeof icons;
+
+${data.mono ? `export type MonoIcons = keyof Icons['mono'];` : ''}
+${data.images ? `export type Images = keyof Icons['images'];` : ''}
+${
+  data.illustration
+    ? `export type Illustrations = keyof Icons['illustration'];`
+    : ''
+}
+`;
+}
+
+function toUniqueObject<T extends TypeConstruct>(list: T[]) {
+  return pickBy(list, (i) => i.id);
+}
+
+function generateData(
+  allFiles: string[],
+  assetTypeInput: AssetType,
+  outputDir: string,
+) {
+  const constructs = allFiles
+    .map((f) => toTypeCoonstruct(f, assetTypeInput, outputDir))
+    .filter(Boolean) as TypeConstruct[];
+
+  const groupedByMode = groupBy(constructs, (i) => i.assetType);
+  const mono = groupedByMode.mono as MonoTypeConstruct[];
+  const colors = groupedByMode.colors
+    ? groupBy(groupedByMode.colors as ColorsTypeConstruct[], (i) => i.colorType)
+    : undefined;
+
+  return {
+    mono: mono ? toUniqueObject(mono) : undefined,
+    images: colors?.images ? toUniqueObject(colors.images) : undefined,
+    illustration: colors?.illustrations
+      ? toUniqueObject(colors.illustrations)
+      : undefined,
+  };
+}
+
+type ColorsTypeConstruct = {
+  relative: string;
+  absolute: string;
+  assetType: 'colors';
+  colorType: 'illustrations' | 'images';
+  darkable: boolean;
+  id: string;
+};
+
+type MonoTypeConstruct = {
+  relative: string;
+  absolute: string;
+  assetType: 'mono';
+  id: string;
+};
+
+type TypeConstruct = ColorsTypeConstruct | MonoTypeConstruct;
+function toTypeCoonstruct(
+  absolute: string,
+  assetTypeInput: AssetType,
+  outputDir: string,
+): TypeConstruct | undefined {
+  const relative = absolute.replace(outputDir, '');
+
+  let assetType =
+    assetTypeInput == 'all'
+      ? relative.match(/^.?colors/)
+        ? 'colors'
+        : 'mono'
+      : assetTypeInput;
+
+  if (assetType === 'mono' && relative.match(/(\/dark\/|\/light\/)/)) {
+    return undefined;
+  }
+
+  if (assetType == 'colors') {
+    return {
+      relative,
+      absolute,
+      assetType: 'colors',
+      colorType: isIllustration(relative) ? 'illustrations' : 'images',
+      darkable: isDarkable(relative),
+      id: toIDPath(relative),
+    };
+  }
+
+  return {
+    relative,
+    absolute,
+    assetType: 'mono',
+    id: toIDPath(relative),
+  };
+}
+const darkOrLight = /\/(?:dark|light)\//;
+
+function toIDPath(relative: string) {
+  return relative
+    .replace(darkOrLight, '/')
+    .replace(
+      /^\/(?:(?:mono|colors)\/)?(?:(?:illustrations|images)\/)?(.*)\..{3}$/,
+      '$1',
+    );
+}
+function isDarkable(relative: string) {
+  return relative.match(darkOrLight) !== null;
+}
+function isIllustration(relative: string) {
+  return relative.match(/^\/(?:(?:mono|colors)\/)?illustrations\//) !== null;
+}
+
+const groupBy = <T, K extends keyof any>(list: T[], getKey: (item: T) => K) =>
+  list.reduce((previous, currentItem) => {
+    const group = getKey(currentItem);
+    if (!previous[group]) previous[group] = [];
+    previous[group].push(currentItem);
+    return previous;
+  }, {} as Record<K, T[]>);
+
+const pickBy = <T, K extends keyof any>(list: T[], getKey: (item: T) => K) =>
+  list.reduce((previous, currentItem) => {
+    const group = getKey(currentItem);
+    if (previous[group]) return previous;
+    previous[group] = currentItem;
+    return previous;
+  }, {} as Record<K, T>);

--- a/packages/assets/src/utils.ts
+++ b/packages/assets/src/utils.ts
@@ -4,6 +4,8 @@ export {ThemeVariant};
 import fg from 'fast-glob';
 import normalizeToUnix from 'normalize-path';
 
+export type AssetType = 'colors' | 'all' | 'mono';
+
 export function themeVariantAsString(org: ThemeVariant): string {
   switch (org) {
     case ThemeVariant.Nfk:


### PR DESCRIPTION
When working on Storybook it became even more apparent for the webshop that doing manual file paths isn't the most ergonomic way to interact with icons. We have some needs:

1. Don't want to create bundle with icons that includes several icons we don't use
2. We do want to have static resolving of icons to help us see what icons we have.
3. We do want to have constructs that can automatically set dark/light mode.

This PR generates (fully backwards compatible) types based on all icons that are parsed, either its only mono, colors or all.

**This is currently an experiment to see how we can improve icons in the webshop.**

---

![Screenshot 2022-07-13 at 15 28 08](https://user-images.githubusercontent.com/606374/178745233-d2e73afe-f1f6-41cb-9cf7-2efadf39744a.png)


Docs:

```
Usage: npx @atb-as/generate-assets [options] <type> <orgId>

Arguments:
  type                           Type of assets to generate (choices: "colors", "all", "mono")
  orgId                          Generate for specific organization (choices: "atb", "nfk")

Options:
  -o, --out-dir <o
![Screenshot 2022-07-13 at 15 28 08](https://user-images.githubusercontent.com/606374/178745128-08e98b9b-b6b0-4b2c-b4b3-09601959c9b0.png)
utput>         Output directory
  -ts-o, --ts-out-dir <output>   Output directory for generated typescript
  -d, --debug                    Log all files generated (default: false)
  -nm, --no-generate-mono-theme  Ignore generating themed mono-icons, but keep general mono icons.
  -ts, --generate-ts             Generates typescript resolution file. (default: false)
  -g, --glob [glob]              Pass in custom glob for matching files. (default: "**/*.{svg,png,jpg,jpeg,ico}")
  -h, --help                     display help for command
```


See `-ts` and `-ts-o` where we can specify to generate types and where to place them. Example output of types as seen here:



<details>
<summary>Example output</summary>

```ts
// NB! NB! NB!
// AUTO GENERATED FILE. DON'T CHANGE
// NB! NB! NB!
export const icons = {
  "mono": {
    "devices/Laptop": {
      "relative": "/mono/devices/Laptop.svg",
      "absolute": "/atb/design-system/packages/assets/temp/mono/devices/Laptop.svg",
      "assetType": "mono",
      "id": "devices/Laptop"
    },
    "devices/Phone": {
      "relative": "/mono/devices/Phone.svg",
      "absolute": "/atb/design-system/packages/assets/temp/mono/devices/Phone.svg",
      "assetType": "mono",
      "id": "devices/Phone"
    },
    "actions/Add": {
      "relative": "/mono/actions/Add.svg",
      "absolute": "/atb/design-system/packages/assets/temp/mono/actions/Add.svg",
      "assetType": "mono",
      "id": "actions/Add"
    },
    "actions/Adjust": {
      "relative": "/mono/actions/Adjust.svg",
      "absolute": "/atb/design-system/packages/assets/temp/mono/actions/Adjust.svg",
      "assetType": "mono",
      "id": "actions/Adjust"
    },
    "actions/Chat": {
      "relative": "/mono/actions/Chat.svg",
      "absolute": "/atb/design-system/packages/assets/temp/mono/actions/Chat.svg",
      "assetType": "mono",
      "id": "actions/Chat"
    },
    "actions/Clear": {
      "relative": "/mono/actions/Clear.svg",
      "absolute": "/atb/design-system/packages/assets/temp/mono/actions/Clear.svg",
      "assetType": "mono",
      "id": "actions/Clear"
    },
    "actions/Close": {
      "relative": "/mono/actions/Close.svg",
      "absolute": "/atb/design-system/packages/assets/temp/mono/actions/Close.svg",
      "assetType": "mono",
      "id": "actions/Close"
    },
    "actions/Confirm": {
      "relative": "/mono/actions/Confirm.svg",
      "absolute": "/atb/design-system/packages/assets/temp/mono/actions/Confirm.svg",
      "assetType": "mono",
      "id": "actions/Confirm"
    },
    "actions/Context": {
      "relative": "/mono/actions/Context.svg",
      "absolute": "/atb/design-system/packages/assets/temp/mono/actions/Context.svg",
      "assetType": "mono",
      "id": "actions/Context"
    },
    "actions/Delete": {
      "relative": "/mono/actions/Delete.svg",
      "absolute": "/atb/design-system/packages/assets/temp/mono/actions/Delete.svg",
      "assetType": "mono",
      "id": "actions/Delete"
    },
    "actions/DragHandle": {
      "relative": "/mono/actions/DragHandle.svg",
      "absolute": "/atb/design-system/packages/assets/temp/mono/actions/DragHandle.svg",
      "assetType": "mono",
      "id": "actions/DragHandle"
    },
    "actions/Edit": {
      "relative": "/mono/actions/Edit.svg",
      "absolute": "/atb/design-system/packages/assets/temp/mono/actions/Edit.svg",
      "assetType": "mono",
      "id": "actions/Edit"
    },
    "actions/Feedback copy": {
      "relative": "/mono/actions/Feedback copy.svg",
      "absolute": "/atb/design-system/packages/assets/temp/mono/actions/Feedback copy.svg",
      "assetType": "mono",
      "id": "actions/Feedback copy"
    },
    "actions/Feedback": {
      "relative": "/mono/actions/Feedback.svg",
      "absolute": "/atb/design-system/packages/assets/temp/mono/actions/Feedback.svg",
      "assetType": "mono",
      "id": "actions/Feedback"
    },
    "actions/Interchange": {
      "relative": "/mono/actions/Interchange.svg",
      "absolute": "/atb/design-system/packages/assets/temp/mono/actions/Interchange.svg",
      "assetType": "mono",
      "id": "actions/Interchange"
    },
    "actions/Reorder": {
      "relative": "/mono/actions/Reorder.svg",
      "absolute": "/atb/design-system/packages/assets/temp/mono/actions/Reorder.svg",
      "assetType": "mono",
      "id": "actions/Reorder"
    },
    "actions/Search": {
      "relative": "/mono/actions/Search.svg",
      "absolute": "/atb/design-system/packages/assets/temp/mono/actions/Search.svg",
      "assetType": "mono",
      "id": "actions/Search"
    },
    "actions/SortAscending": {
      "relative": "/mono/actions/SortAscending.svg",
      "absolute": "/atb/design-system/packages/assets/temp/mono/actions/SortAscending.svg",
      "assetType": "mono",
      "id": "actions/SortAscending"
    },
    "actions/SortDescending": {
      "relative": "/mono/actions/SortDescending.svg",
      "absolute": "/atb/design-system/packages/assets/temp/mono/actions/SortDescending.svg",
      "assetType": "mono",
      "id": "actions/SortDescending"
    },
    "actions/Subtract": {
      "relative": "/mono/actions/Subtract.svg",
      "absolute": "/atb/design-system/packages/assets/temp/mono/actions/Subtract.svg",
      "assetType": "mono",
      "id": "actions/Subtract"
    },
    "actions/Support": {
      "relative": "/mono/actions/Support.svg",
      "absolute": "/atb/design-system/packages/assets/temp/mono/actions/Support.svg",
      "assetType": "mono",
      "id": "actions/Support"
    },
    "actions/Swap": {
      "relative": "/mono/actions/Swap.svg",
      "absolute": "/atb/design-system/packages/assets/temp/mono/actions/Swap.svg",
      "assetType": "mono",
      "id": "actions/Swap"
    },
    "map/Map": {
      "relative": "/mono/map/Map.svg",
      "absolute": "/atb/design-system/packages/assets/temp/mono/map/Map.svg",
      "assetType": "mono",
      "id": "map/Map"
    },
    "map/MapPin": {
      "relative": "/mono/map/MapPin.svg",
      "absolute": "/atb/design-system/packages/assets/temp/mono/map/MapPin.svg",
      "assetType": "mono",
      "id": "map/MapPin"
    },
    "map/Pin": {
      "relative": "/mono/map/Pin.svg",
      "absolute": "/atb/design-system/packages/assets/temp/mono/map/Pin.svg",
      "assetType": "mono",
      "id": "map/Pin"
    },
    "map/PinInvalid": {
      "relative": "/mono/map/PinInvalid.svg",
      "absolute": "/atb/design-system/packages/assets/temp/mono/map/PinInvalid.svg",
      "assetType": "mono",
      "id": "map/PinInvalid"
    },
    "map/PinValid": {
      "relative": "/mono/map/PinValid.svg",
      "absolute": "/atb/design-system/packages/assets/temp/mono/map/PinValid.svg",
      "assetType": "mono",
      "id": "map/PinValid"
    },
    "status/Check": {
      "relative": "/mono/status/Check.svg",
      "absolute": "/atb/design-system/packages/assets/temp/mono/status/Check.svg",
      "assetType": "mono",
      "id": "status/Check"
    },
    "status/Error": {
      "relative": "/mono/status/Error.svg",
      "absolute": "/atb/design-system/packages/assets/temp/mono/status/Error.svg",
      "assetType": "mono",
      "id": "status/Error"
    },
    "status/Info": {
      "relative": "/mono/status/Info.svg",
      "absolute": "/atb/design-system/packages/assets/temp/mono/status/Info.svg",
      "assetType": "mono",
      "id": "status/Info"
    },
    "status/ServiceDisruption": {
      "relative": "/mono/status/ServiceDisruption.svg",
      "absolute": "/atb/design-system/packages/assets/temp/mono/status/ServiceDisruption.svg",
      "assetType": "mono",
      "id": "status/ServiceDisruption"
    },
    "status/Spinner": {
      "relative": "/mono/status/Spinner.svg",
      "absolute": "/atb/design-system/packages/assets/temp/mono/status/Spinner.svg",
      "assetType": "mono",
      "id": "status/Spinner"
    },
    "status/Unknown": {
      "relative": "/mono/status/Unknown.svg",
      "absolute": "/atb/design-system/packages/assets/temp/mono/status/Unknown.svg",
      "assetType": "mono",
      "id": "status/Unknown"
    },
    "status/Warning": {
      "relative": "/mono/status/Warning.svg",
      "absolute": "/atb/design-system/packages/assets/temp/mono/status/Warning.svg",
      "assetType": "mono",
      "id": "status/Warning"
    },
    "tab-bar/assistant": {
      "relative": "/mono/tab-bar/assistant.svg",
      "absolute": "/atb/design-system/packages/assets/temp/mono/tab-bar/assistant.svg",
      "assetType": "mono",
      "id": "tab-bar/assistant"
    },
    "tab-bar/departures": {
      "relative": "/mono/tab-bar/departures.svg",
      "absolute": "/atb/design-system/packages/assets/temp/mono/tab-bar/departures.svg",
      "assetType": "mono",
      "id": "tab-bar/departures"
    },
    "tab-bar/profile": {
      "relative": "/mono/tab-bar/profile.svg",
      "absolute": "/atb/design-system/packages/assets/temp/mono/tab-bar/profile.svg",
      "assetType": "mono",
      "id": "tab-bar/profile"
    },
    "tab-bar/ticketing": {
      "relative": "/mono/tab-bar/ticketing.svg",
      "absolute": "/atb/design-system/packages/assets/temp/mono/tab-bar/ticketing.svg",
      "assetType": "mono",
      "id": "tab-bar/ticketing"
    },
    "ticketing/Card": {
      "relative": "/mono/ticketing/Card.svg",
      "absolute": "/atb/design-system/packages/assets/temp/mono/ticketing/Card.svg",
      "assetType": "mono",
      "id": "ticketing/Card"
    },
    "ticketing/H24": {
      "relative": "/mono/ticketing/H24.svg",
      "absolute": "/atb/design-system/packages/assets/temp/mono/ticketing/H24.svg",
      "assetType": "mono",
      "id": "ticketing/H24"
    },
    "ticketing/Moon": {
      "relative": "/mono/ticketing/Moon.svg",
      "absolute": "/atb/design-system/packages/assets/temp/mono/ticketing/Moon.svg",
      "assetType": "mono",
      "id": "ticketing/Moon"
    },
    "ticketing/QR": {
      "relative": "/mono/ticketing/QR.svg",
      "absolute": "/atb/design-system/packages/assets/temp/mono/ticketing/QR.svg",
      "assetType": "mono",
      "id": "ticketing/QR"
    },
    "ticketing/Sun": {
      "relative": "/mono/ticketing/Sun.svg",
      "absolute": "/atb/design-system/packages/assets/temp/mono/ticketing/Sun.svg",
      "assetType": "mono",
      "id": "ticketing/Sun"
    },
    "ticketing/Ticket": {
      "relative": "/mono/ticketing/Ticket.svg",
      "absolute": "/atb/design-system/packages/assets/temp/mono/ticketing/Ticket.svg",
      "assetType": "mono",
      "id": "ticketing/Ticket"
    },
    "ticketing/TicketAdd": {
      "relative": "/mono/ticketing/TicketAdd.svg",
      "absolute": "/atb/design-system/packages/assets/temp/mono/ticketing/TicketAdd.svg",
      "assetType": "mono",
      "id": "ticketing/TicketAdd"
    },
    "ticketing/TicketInvalid": {
      "relative": "/mono/ticketing/TicketInvalid.svg",
      "absolute": "/atb/design-system/packages/assets/temp/mono/ticketing/TicketInvalid.svg",
      "assetType": "mono",
      "id": "ticketing/TicketInvalid"
    },
    "ticketing/TicketMultiple": {
      "relative": "/mono/ticketing/TicketMultiple.svg",
      "absolute": "/atb/design-system/packages/assets/temp/mono/ticketing/TicketMultiple.svg",
      "assetType": "mono",
      "id": "ticketing/TicketMultiple"
    },
    "ticketing/TicketValid": {
      "relative": "/mono/ticketing/TicketValid.svg",
      "absolute": "/atb/design-system/packages/assets/temp/mono/ticketing/TicketValid.svg",
      "assetType": "mono",
      "id": "ticketing/TicketValid"
    },
    "ticketing/Travellers": {
      "relative": "/mono/ticketing/Travellers.svg",
      "absolute": "/atb/design-system/packages/assets/temp/mono/ticketing/Travellers.svg",
      "assetType": "mono",
      "id": "ticketing/Travellers"
    },
    "ticketing/Vipps": {
      "relative": "/mono/ticketing/Vipps.svg",
      "absolute": "/atb/design-system/packages/assets/temp/mono/ticketing/Vipps.svg",
      "assetType": "mono",
      "id": "ticketing/Vipps"
    },
    "ticketing/Youth": {
      "relative": "/mono/ticketing/Youth.svg",
      "absolute": "/atb/design-system/packages/assets/temp/mono/ticketing/Youth.svg",
      "assetType": "mono",
      "id": "ticketing/Youth"
    },
    "time/Date": {
      "relative": "/mono/time/Date.svg",
      "absolute": "/atb/design-system/packages/assets/temp/mono/time/Date.svg",
      "assetType": "mono",
      "id": "time/Date"
    },
    "time/Duration": {
      "relative": "/mono/time/Duration.svg",
      "absolute": "/atb/design-system/packages/assets/temp/mono/time/Duration.svg",
      "assetType": "mono",
      "id": "time/Duration"
    },
    "time/Realtime": {
      "relative": "/mono/time/Realtime.svg",
      "absolute": "/atb/design-system/packages/assets/temp/mono/time/Realtime.svg",
      "assetType": "mono",
      "id": "time/Realtime"
    },
    "time/RealtimeSmall": {
      "relative": "/mono/time/RealtimeSmall.svg",
      "absolute": "/atb/design-system/packages/assets/temp/mono/time/RealtimeSmall.svg",
      "assetType": "mono",
      "id": "time/RealtimeSmall"
    },
    "time/Time": {
      "relative": "/mono/time/Time.svg",
      "absolute": "/atb/design-system/packages/assets/temp/mono/time/Time.svg",
      "assetType": "mono",
      "id": "time/Time"
    },
    "transportation/Boat": {
      "relative": "/mono/transportation/Boat.svg",
      "absolute": "/atb/design-system/packages/assets/temp/mono/transportation/Boat.svg",
      "assetType": "mono",
      "id": "transportation/Boat"
    },
    "transportation/Bus": {
      "relative": "/mono/transportation/Bus.svg",
      "absolute": "/atb/design-system/packages/assets/temp/mono/transportation/Bus.svg",
      "assetType": "mono",
      "id": "transportation/Bus"
    },
    "transportation/Car": {
      "relative": "/mono/transportation/Car.svg",
      "absolute": "/atb/design-system/packages/assets/temp/mono/transportation/Car.svg",
      "assetType": "mono",
      "id": "transportation/Car"
    },
    "transportation/Ferry": {
      "relative": "/mono/transportation/Ferry.svg",
      "absolute": "/atb/design-system/packages/assets/temp/mono/transportation/Ferry.svg",
      "assetType": "mono",
      "id": "transportation/Ferry"
    },
    "transportation/Train": {
      "relative": "/mono/transportation/Train.svg",
      "absolute": "/atb/design-system/packages/assets/temp/mono/transportation/Train.svg",
      "assetType": "mono",
      "id": "transportation/Train"
    },
    "transportation/Tram": {
      "relative": "/mono/transportation/Tram.svg",
      "absolute": "/atb/design-system/packages/assets/temp/mono/transportation/Tram.svg",
      "assetType": "mono",
      "id": "transportation/Tram"
    },
    "transportation/Walk": {
      "relative": "/mono/transportation/Walk.svg",
      "absolute": "/atb/design-system/packages/assets/temp/mono/transportation/Walk.svg",
      "assetType": "mono",
      "id": "transportation/Walk"
    },
    "places/City": {
      "relative": "/mono/places/City.svg",
      "absolute": "/atb/design-system/packages/assets/temp/mono/places/City.svg",
      "assetType": "mono",
      "id": "places/City"
    },
    "places/Destination": {
      "relative": "/mono/places/Destination.svg",
      "absolute": "/atb/design-system/packages/assets/temp/mono/places/Destination.svg",
      "assetType": "mono",
      "id": "places/Destination"
    },
    "places/Favorite": {
      "relative": "/mono/places/Favorite.svg",
      "absolute": "/atb/design-system/packages/assets/temp/mono/places/Favorite.svg",
      "assetType": "mono",
      "id": "places/Favorite"
    },
    "places/FavoriteDisable": {
      "relative": "/mono/places/FavoriteDisable.svg",
      "absolute": "/atb/design-system/packages/assets/temp/mono/places/FavoriteDisable.svg",
      "assetType": "mono",
      "id": "places/FavoriteDisable"
    },
    "places/FavoriteFill": {
      "relative": "/mono/places/FavoriteFill.svg",
      "absolute": "/atb/design-system/packages/assets/temp/mono/places/FavoriteFill.svg",
      "assetType": "mono",
      "id": "places/FavoriteFill"
    },
    "places/FavoriteSemi": {
      "relative": "/mono/places/FavoriteSemi.svg",
      "absolute": "/atb/design-system/packages/assets/temp/mono/places/FavoriteSemi.svg",
      "assetType": "mono",
      "id": "places/FavoriteSemi"
    },
    "places/House": {
      "relative": "/mono/places/House.svg",
      "absolute": "/atb/design-system/packages/assets/temp/mono/places/House.svg",
      "assetType": "mono",
      "id": "places/House"
    },
    "places/Location": {
      "relative": "/mono/places/Location.svg",
      "absolute": "/atb/design-system/packages/assets/temp/mono/places/Location.svg",
      "assetType": "mono",
      "id": "places/Location"
    },
    "places/Stop": {
      "relative": "/mono/places/Stop.svg",
      "absolute": "/atb/design-system/packages/assets/temp/mono/places/Stop.svg",
      "assetType": "mono",
      "id": "places/Stop"
    },
    "places/StopDestination": {
      "relative": "/mono/places/StopDestination.svg",
      "absolute": "/atb/design-system/packages/assets/temp/mono/places/StopDestination.svg",
      "assetType": "mono",
      "id": "places/StopDestination"
    },
    "places/StopOrigin": {
      "relative": "/mono/places/StopOrigin.svg",
      "absolute": "/atb/design-system/packages/assets/temp/mono/places/StopOrigin.svg",
      "assetType": "mono",
      "id": "places/StopOrigin"
    },
    "navigation/ArrowLeft": {
      "relative": "/mono/navigation/ArrowLeft.svg",
      "absolute": "/atb/design-system/packages/assets/temp/mono/navigation/ArrowLeft.svg",
      "assetType": "mono",
      "id": "navigation/ArrowLeft"
    },
    "navigation/ArrowRight": {
      "relative": "/mono/navigation/ArrowRight.svg",
      "absolute": "/atb/design-system/packages/assets/temp/mono/navigation/ArrowRight.svg",
      "assetType": "mono",
      "id": "navigation/ArrowRight"
    },
    "navigation/ArrowUpLeft": {
      "relative": "/mono/navigation/ArrowUpLeft.svg",
      "absolute": "/atb/design-system/packages/assets/temp/mono/navigation/ArrowUpLeft.svg",
      "assetType": "mono",
      "id": "navigation/ArrowUpLeft"
    },
    "navigation/ChevronLeft": {
      "relative": "/mono/navigation/ChevronLeft.svg",
      "absolute": "/atb/design-system/packages/assets/temp/mono/navigation/ChevronLeft.svg",
      "assetType": "mono",
      "id": "navigation/ChevronLeft"
    },
    "navigation/ChevronRight": {
      "relative": "/mono/navigation/ChevronRight.svg",
      "absolute": "/atb/design-system/packages/assets/temp/mono/navigation/ChevronRight.svg",
      "assetType": "mono",
      "id": "navigation/ChevronRight"
    },
    "navigation/ExpandLess": {
      "relative": "/mono/navigation/ExpandLess.svg",
      "absolute": "/atb/design-system/packages/assets/temp/mono/navigation/ExpandLess.svg",
      "assetType": "mono",
      "id": "navigation/ExpandLess"
    },
    "navigation/ExpandMore": {
      "relative": "/mono/navigation/ExpandMore.svg",
      "absolute": "/atb/design-system/packages/assets/temp/mono/navigation/ExpandMore.svg",
      "assetType": "mono",
      "id": "navigation/ExpandMore"
    },
    "navigation/ExternalLink": {
      "relative": "/mono/navigation/ExternalLink.svg",
      "absolute": "/atb/design-system/packages/assets/temp/mono/navigation/ExternalLink.svg",
      "assetType": "mono",
      "id": "navigation/ExternalLink"
    },
    "navigation/UnfoldLess": {
      "relative": "/mono/navigation/UnfoldLess.svg",
      "absolute": "/atb/design-system/packages/assets/temp/mono/navigation/UnfoldLess.svg",
      "assetType": "mono",
      "id": "navigation/UnfoldLess"
    },
    "navigation/UnfoldMore": {
      "relative": "/mono/navigation/UnfoldMore.svg",
      "absolute": "/atb/design-system/packages/assets/temp/mono/navigation/UnfoldMore.svg",
      "assetType": "mono",
      "id": "navigation/UnfoldMore"
    },
    "profile/LogOut": {
      "relative": "/mono/profile/LogOut.svg",
      "absolute": "/atb/design-system/packages/assets/temp/mono/profile/LogOut.svg",
      "assetType": "mono",
      "id": "profile/LogOut"
    },
    "profile/Mail": {
      "relative": "/mono/profile/Mail.svg",
      "absolute": "/atb/design-system/packages/assets/temp/mono/profile/Mail.svg",
      "assetType": "mono",
      "id": "profile/Mail"
    },
    "profile/Phone": {
      "relative": "/mono/profile/Phone.svg",
      "absolute": "/atb/design-system/packages/assets/temp/mono/profile/Phone.svg",
      "assetType": "mono",
      "id": "profile/Phone"
    },
    "profile/User": {
      "relative": "/mono/profile/User.svg",
      "absolute": "/atb/design-system/packages/assets/temp/mono/profile/User.svg",
      "assetType": "mono",
      "id": "profile/User"
    },
    "transportation-entur/Bicycle": {
      "relative": "/mono/transportation-entur/Bicycle.svg",
      "absolute": "/atb/design-system/packages/assets/temp/mono/transportation-entur/Bicycle.svg",
      "assetType": "mono",
      "id": "transportation-entur/Bicycle"
    },
    "transportation-entur/Bus": {
      "relative": "/mono/transportation-entur/Bus.svg",
      "absolute": "/atb/design-system/packages/assets/temp/mono/transportation-entur/Bus.svg",
      "assetType": "mono",
      "id": "transportation-entur/Bus"
    },
    "transportation-entur/Cableway": {
      "relative": "/mono/transportation-entur/Cableway.svg",
      "absolute": "/atb/design-system/packages/assets/temp/mono/transportation-entur/Cableway.svg",
      "assetType": "mono",
      "id": "transportation-entur/Cableway"
    },
    "transportation-entur/Car": {
      "relative": "/mono/transportation-entur/Car.svg",
      "absolute": "/atb/design-system/packages/assets/temp/mono/transportation-entur/Car.svg",
      "assetType": "mono",
      "id": "transportation-entur/Car"
    },
    "transportation-entur/Carferry": {
      "relative": "/mono/transportation-entur/Carferry.svg",
      "absolute": "/atb/design-system/packages/assets/temp/mono/transportation-entur/Carferry.svg",
      "assetType": "mono",
      "id": "transportation-entur/Carferry"
    },
    "transportation-entur/Ferry": {
      "relative": "/mono/transportation-entur/Ferry.svg",
      "absolute": "/atb/design-system/packages/assets/temp/mono/transportation-entur/Ferry.svg",
      "assetType": "mono",
      "id": "transportation-entur/Ferry"
    },
    "transportation-entur/Funicular": {
      "relative": "/mono/transportation-entur/Funicular.svg",
      "absolute": "/atb/design-system/packages/assets/temp/mono/transportation-entur/Funicular.svg",
      "assetType": "mono",
      "id": "transportation-entur/Funicular"
    },
    "transportation-entur/Helicopter": {
      "relative": "/mono/transportation-entur/Helicopter.svg",
      "absolute": "/atb/design-system/packages/assets/temp/mono/transportation-entur/Helicopter.svg",
      "assetType": "mono",
      "id": "transportation-entur/Helicopter"
    },
    "transportation-entur/Plane": {
      "relative": "/mono/transportation-entur/Plane.svg",
      "absolute": "/atb/design-system/packages/assets/temp/mono/transportation-entur/Plane.svg",
      "assetType": "mono",
      "id": "transportation-entur/Plane"
    },
    "transportation-entur/Scooter": {
      "relative": "/mono/transportation-entur/Scooter.svg",
      "absolute": "/atb/design-system/packages/assets/temp/mono/transportation-entur/Scooter.svg",
      "assetType": "mono",
      "id": "transportation-entur/Scooter"
    },
    "transportation-entur/Subway": {
      "relative": "/mono/transportation-entur/Subway.svg",
      "absolute": "/atb/design-system/packages/assets/temp/mono/transportation-entur/Subway.svg",
      "assetType": "mono",
      "id": "transportation-entur/Subway"
    },
    "transportation-entur/Taxi": {
      "relative": "/mono/transportation-entur/Taxi.svg",
      "absolute": "/atb/design-system/packages/assets/temp/mono/transportation-entur/Taxi.svg",
      "assetType": "mono",
      "id": "transportation-entur/Taxi"
    },
    "transportation-entur/Train": {
      "relative": "/mono/transportation-entur/Train.svg",
      "absolute": "/atb/design-system/packages/assets/temp/mono/transportation-entur/Train.svg",
      "assetType": "mono",
      "id": "transportation-entur/Train"
    },
    "transportation-entur/Tram": {
      "relative": "/mono/transportation-entur/Tram.svg",
      "absolute": "/atb/design-system/packages/assets/temp/mono/transportation-entur/Tram.svg",
      "assetType": "mono",
      "id": "transportation-entur/Tram"
    },
    "transportation-entur/Walk": {
      "relative": "/mono/transportation-entur/Walk.svg",
      "absolute": "/atb/design-system/packages/assets/temp/mono/transportation-entur/Walk.svg",
      "assetType": "mono",
      "id": "transportation-entur/Walk"
    },
    "logo/logo": {
      "relative": "/mono/logo/logo.svg",
      "absolute": "/atb/design-system/packages/assets/temp/mono/logo/logo.svg",
      "assetType": "mono",
      "id": "logo/logo"
    },
    "ticketing/Travelcard": {
      "relative": "/mono/ticketing/Travelcard.svg",
      "absolute": "/atb/design-system/packages/assets/temp/mono/ticketing/Travelcard.svg",
      "assetType": "mono",
      "id": "ticketing/Travelcard"
    },
    "ticketing/TravelcardOutlined": {
      "relative": "/mono/ticketing/TravelcardOutlined.svg",
      "absolute": "/atb/design-system/packages/assets/temp/mono/ticketing/TravelcardOutlined.svg",
      "assetType": "mono",
      "id": "ticketing/TravelcardOutlined"
    }
  },
  "images": {
    "ChangeTravelToken": {
      "relative": "/colors/images/ChangeTravelToken.svg",
      "absolute": "/atb/design-system/packages/assets/temp/colors/images/ChangeTravelToken.svg",
      "assetType": "colors",
      "colorType": "images",
      "darkable": false,
      "id": "ChangeTravelToken"
    },
    "Periodebillett": {
      "relative": "/colors/images/Periodebillett.svg",
      "absolute": "/atb/design-system/packages/assets/temp/colors/images/Periodebillett.svg",
      "assetType": "colors",
      "colorType": "images",
      "darkable": false,
      "id": "Periodebillett"
    },
    "Ticket": {
      "relative": "/colors/images/Ticket.svg",
      "absolute": "/atb/design-system/packages/assets/temp/colors/images/Ticket.svg",
      "assetType": "colors",
      "colorType": "images",
      "darkable": false,
      "id": "Ticket"
    },
    "TicketNew": {
      "relative": "/colors/images/TicketNew.svg",
      "absolute": "/atb/design-system/packages/assets/temp/colors/images/TicketNew.svg",
      "assetType": "colors",
      "colorType": "images",
      "darkable": false,
      "id": "TicketNew"
    },
    "waving-hand": {
      "relative": "/colors/images/waving-hand.png",
      "absolute": "/atb/design-system/packages/assets/temp/colors/images/waving-hand.png",
      "assetType": "colors",
      "colorType": "images",
      "darkable": false,
      "id": "waving-hand"
    },
    "icons/actions/ChatUnread": {
      "relative": "/colors/icons/actions/ChatUnread.svg",
      "absolute": "/atb/design-system/packages/assets/temp/colors/icons/actions/ChatUnread.svg",
      "assetType": "colors",
      "colorType": "images",
      "darkable": false,
      "id": "icons/actions/ChatUnread"
    },
    "icons/input/CheckboxChecked": {
      "relative": "/colors/icons/input/CheckboxChecked.svg",
      "absolute": "/atb/design-system/packages/assets/temp/colors/icons/input/CheckboxChecked.svg",
      "assetType": "colors",
      "colorType": "images",
      "darkable": false,
      "id": "icons/input/CheckboxChecked"
    },
    "icons/input/CheckboxUnchecked": {
      "relative": "/colors/icons/input/CheckboxUnchecked.svg",
      "absolute": "/atb/design-system/packages/assets/temp/colors/icons/input/CheckboxUnchecked.svg",
      "assetType": "colors",
      "colorType": "images",
      "darkable": false,
      "id": "icons/input/CheckboxUnchecked"
    },
    "icons/input/RadiobuttonChecked": {
      "relative": "/colors/icons/input/RadiobuttonChecked.svg",
      "absolute": "/atb/design-system/packages/assets/temp/colors/icons/input/RadiobuttonChecked.svg",
      "assetType": "colors",
      "colorType": "images",
      "darkable": false,
      "id": "icons/input/RadiobuttonChecked"
    },
    "icons/input/RadiobuttonUnchecked": {
      "relative": "/colors/icons/input/RadiobuttonUnchecked.svg",
      "absolute": "/atb/design-system/packages/assets/temp/colors/icons/input/RadiobuttonUnchecked.svg",
      "assetType": "colors",
      "colorType": "images",
      "darkable": false,
      "id": "icons/input/RadiobuttonUnchecked"
    },
    "icons/map/Map": {
      "relative": "/colors/icons/map/Map.svg",
      "absolute": "/atb/design-system/packages/assets/temp/colors/icons/map/Map.svg",
      "assetType": "colors",
      "colorType": "images",
      "darkable": false,
      "id": "icons/map/Map"
    },
    "icons/map/MapPin": {
      "relative": "/colors/icons/map/MapPin.svg",
      "absolute": "/atb/design-system/packages/assets/temp/colors/icons/map/MapPin.svg",
      "assetType": "colors",
      "colorType": "images",
      "darkable": false,
      "id": "icons/map/MapPin"
    },
    "icons/map/Pin": {
      "relative": "/colors/icons/map/Pin.svg",
      "absolute": "/atb/design-system/packages/assets/temp/colors/icons/map/Pin.svg",
      "assetType": "colors",
      "colorType": "images",
      "darkable": false,
      "id": "icons/map/Pin"
    },
    "icons/map/PinInvalid": {
      "relative": "/colors/icons/map/PinInvalid.svg",
      "absolute": "/atb/design-system/packages/assets/temp/colors/icons/map/PinInvalid.svg",
      "assetType": "colors",
      "colorType": "images",
      "darkable": false,
      "id": "icons/map/PinInvalid"
    },
    "icons/map/PinValid": {
      "relative": "/colors/icons/map/PinValid.svg",
      "absolute": "/atb/design-system/packages/assets/temp/colors/icons/map/PinValid.svg",
      "assetType": "colors",
      "colorType": "images",
      "darkable": false,
      "id": "icons/map/PinValid"
    },
    "icons/ticketing/Klippekort": {
      "relative": "/colors/icons/ticketing/Klippekort.svg",
      "absolute": "/atb/design-system/packages/assets/temp/colors/icons/ticketing/Klippekort.svg",
      "assetType": "colors",
      "colorType": "images",
      "darkable": false,
      "id": "icons/ticketing/Klippekort"
    },
    "icons/ticketing/MasterCard": {
      "relative": "/colors/icons/ticketing/MasterCard.svg",
      "absolute": "/atb/design-system/packages/assets/temp/colors/icons/ticketing/MasterCard.svg",
      "assetType": "colors",
      "colorType": "images",
      "darkable": false,
      "id": "icons/ticketing/MasterCard"
    },
    "icons/ticketing/Seats": {
      "relative": "/colors/icons/ticketing/Seats.svg",
      "absolute": "/atb/design-system/packages/assets/temp/colors/icons/ticketing/Seats.svg",
      "assetType": "colors",
      "colorType": "images",
      "darkable": false,
      "id": "icons/ticketing/Seats"
    },
    "icons/ticketing/Vipps": {
      "relative": "/colors/icons/ticketing/Vipps.svg",
      "absolute": "/atb/design-system/packages/assets/temp/colors/icons/ticketing/Vipps.svg",
      "assetType": "colors",
      "colorType": "images",
      "darkable": false,
      "id": "icons/ticketing/Vipps"
    },
    "icons/ticketing/Visa": {
      "relative": "/colors/icons/ticketing/Visa.svg",
      "absolute": "/atb/design-system/packages/assets/temp/colors/icons/ticketing/Visa.svg",
      "assetType": "colors",
      "colorType": "images",
      "darkable": false,
      "id": "icons/ticketing/Visa"
    },
    "icons/status/Check": {
      "relative": "/colors/icons/status/Check.svg",
      "absolute": "/atb/design-system/packages/assets/temp/colors/icons/status/Check.svg",
      "assetType": "colors",
      "colorType": "images",
      "darkable": false,
      "id": "icons/status/Check"
    },
    "icons/status/Error": {
      "relative": "/colors/icons/status/Error.svg",
      "absolute": "/atb/design-system/packages/assets/temp/colors/icons/status/Error.svg",
      "assetType": "colors",
      "colorType": "images",
      "darkable": false,
      "id": "icons/status/Error"
    },
    "icons/status/Info": {
      "relative": "/colors/icons/status/Info.svg",
      "absolute": "/atb/design-system/packages/assets/temp/colors/icons/status/Info.svg",
      "assetType": "colors",
      "colorType": "images",
      "darkable": false,
      "id": "icons/status/Info"
    },
    "icons/status/Realtime": {
      "relative": "/colors/icons/status/Realtime.svg",
      "absolute": "/atb/design-system/packages/assets/temp/colors/icons/status/Realtime.svg",
      "assetType": "colors",
      "colorType": "images",
      "darkable": false,
      "id": "icons/status/Realtime"
    },
    "icons/status/Warning": {
      "relative": "/colors/icons/status/Warning.svg",
      "absolute": "/atb/design-system/packages/assets/temp/colors/icons/status/Warning.svg",
      "assetType": "colors",
      "colorType": "images",
      "darkable": false,
      "id": "icons/status/Warning"
    },
    "icons/status/Spinner": {
      "relative": "/colors/icons/status/dark/Spinner.svg",
      "absolute": "/atb/design-system/packages/assets/temp/colors/icons/status/dark/Spinner.svg",
      "assetType": "colors",
      "colorType": "images",
      "darkable": true,
      "id": "icons/status/Spinner"
    },
    "favicon": {
      "relative": "/colors/favicon.ico",
      "absolute": "/atb/design-system/packages/assets/temp/colors/favicon.ico",
      "assetType": "colors",
      "colorType": "images",
      "darkable": false,
      "id": "favicon"
    },
    "icons/favicon": {
      "relative": "/colors/icons/favicon.svg",
      "absolute": "/atb/design-system/packages/assets/temp/colors/icons/favicon.svg",
      "assetType": "colors",
      "colorType": "images",
      "darkable": false,
      "id": "icons/favicon"
    },
    "AppPreview": {
      "relative": "/colors/images/AppPreview.png",
      "absolute": "/atb/design-system/packages/assets/temp/colors/images/AppPreview.png",
      "assetType": "colors",
      "colorType": "images",
      "darkable": false,
      "id": "AppPreview"
    },
    "Crash": {
      "relative": "/colors/images/Crash.svg",
      "absolute": "/atb/design-system/packages/assets/temp/colors/images/Crash.svg",
      "assetType": "colors",
      "colorType": "images",
      "darkable": false,
      "id": "Crash"
    },
    "CrashSmall": {
      "relative": "/colors/images/CrashSmall.svg",
      "absolute": "/atb/design-system/packages/assets/temp/colors/images/CrashSmall.svg",
      "assetType": "colors",
      "colorType": "images",
      "darkable": false,
      "id": "CrashSmall"
    },
    "OnBehalfOf": {
      "relative": "/colors/images/OnBehalfOf.svg",
      "absolute": "/atb/design-system/packages/assets/temp/colors/images/OnBehalfOf.svg",
      "assetType": "colors",
      "colorType": "images",
      "darkable": false,
      "id": "OnBehalfOf"
    },
    "Onboarding1": {
      "relative": "/colors/images/Onboarding1.svg",
      "absolute": "/atb/design-system/packages/assets/temp/colors/images/Onboarding1.svg",
      "assetType": "colors",
      "colorType": "images",
      "darkable": false,
      "id": "Onboarding1"
    },
    "Onboarding2": {
      "relative": "/colors/images/Onboarding2.svg",
      "absolute": "/atb/design-system/packages/assets/temp/colors/images/Onboarding2.svg",
      "assetType": "colors",
      "colorType": "images",
      "darkable": false,
      "id": "Onboarding2"
    },
    "Onboarding3": {
      "relative": "/colors/images/Onboarding3.svg",
      "absolute": "/atb/design-system/packages/assets/temp/colors/images/Onboarding3.svg",
      "assetType": "colors",
      "colorType": "images",
      "darkable": false,
      "id": "Onboarding3"
    },
    "PhotoBackground": {
      "relative": "/colors/images/PhotoBackground.jpg",
      "absolute": "/atb/design-system/packages/assets/temp/colors/images/PhotoBackground.jpg",
      "assetType": "colors",
      "colorType": "images",
      "darkable": false,
      "id": "PhotoBackground"
    },
    "Pilot": {
      "relative": "/colors/images/Pilot.svg",
      "absolute": "/atb/design-system/packages/assets/temp/colors/images/Pilot.svg",
      "assetType": "colors",
      "colorType": "images",
      "darkable": false,
      "id": "Pilot"
    },
    "TicketSplash": {
      "relative": "/colors/images/TicketSplash.svg",
      "absolute": "/atb/design-system/packages/assets/temp/colors/images/TicketSplash.svg",
      "assetType": "colors",
      "colorType": "images",
      "darkable": false,
      "id": "TicketSplash"
    },
    "TravelPlanning": {
      "relative": "/colors/images/TravelPlanning.svg",
      "absolute": "/atb/design-system/packages/assets/temp/colors/images/TravelPlanning.svg",
      "assetType": "colors",
      "colorType": "images",
      "darkable": false,
      "id": "TravelPlanning"
    },
    "TravelcardHelpIllustration": {
      "relative": "/colors/images/TravelcardHelpIllustration.svg",
      "absolute": "/atb/design-system/packages/assets/temp/colors/images/TravelcardHelpIllustration.svg",
      "assetType": "colors",
      "colorType": "images",
      "darkable": false,
      "id": "TravelcardHelpIllustration"
    },
    "BackgroundIllustration-OnBehalfOf": {
      "relative": "/colors/images/dark/BackgroundIllustration-OnBehalfOf.svg",
      "absolute": "/atb/design-system/packages/assets/temp/colors/images/dark/BackgroundIllustration-OnBehalfOf.svg",
      "assetType": "colors",
      "colorType": "images",
      "darkable": true,
      "id": "BackgroundIllustration-OnBehalfOf"
    },
    "BackgroundIllustration": {
      "relative": "/colors/images/dark/BackgroundIllustration.svg",
      "absolute": "/atb/design-system/packages/assets/temp/colors/images/dark/BackgroundIllustration.svg",
      "assetType": "colors",
      "colorType": "images",
      "darkable": true,
      "id": "BackgroundIllustration"
    },
    "EmptyIllustration": {
      "relative": "/colors/images/dark/EmptyIllustration.svg",
      "absolute": "/atb/design-system/packages/assets/temp/colors/images/dark/EmptyIllustration.svg",
      "assetType": "colors",
      "colorType": "images",
      "darkable": true,
      "id": "EmptyIllustration"
    },
    "TravelIllustration": {
      "relative": "/colors/images/dark/TravelIllustration.svg",
      "absolute": "/atb/design-system/packages/assets/temp/colors/images/dark/TravelIllustration.svg",
      "assetType": "colors",
      "colorType": "images",
      "darkable": true,
      "id": "TravelIllustration"
    },
    "TravelcardHelpIcons": {
      "relative": "/colors/images/dark/TravelcardHelpIcons.svg",
      "absolute": "/atb/design-system/packages/assets/temp/colors/images/dark/TravelcardHelpIcons.svg",
      "assetType": "colors",
      "colorType": "images",
      "darkable": true,
      "id": "TravelcardHelpIcons"
    }
  },
  "illustration": {
    "Cloud": {
      "relative": "/colors/illustrations/Cloud.svg",
      "absolute": "/atb/design-system/packages/assets/temp/colors/illustrations/Cloud.svg",
      "assetType": "colors",
      "colorType": "illustrations",
      "darkable": false,
      "id": "Cloud"
    },
    "Menu": {
      "relative": "/colors/illustrations/Menu.svg",
      "absolute": "/atb/design-system/packages/assets/temp/colors/illustrations/Menu.svg",
      "assetType": "colors",
      "colorType": "illustrations",
      "darkable": false,
      "id": "Menu"
    },
    "PassengerCategory": {
      "relative": "/colors/illustrations/PassengerCategory.svg",
      "absolute": "/atb/design-system/packages/assets/temp/colors/illustrations/PassengerCategory.svg",
      "assetType": "colors",
      "colorType": "illustrations",
      "darkable": false,
      "id": "PassengerCategory"
    },
    "PassengerCategoryChecked": {
      "relative": "/colors/illustrations/PassengerCategoryChecked.svg",
      "absolute": "/atb/design-system/packages/assets/temp/colors/illustrations/PassengerCategoryChecked.svg",
      "assetType": "colors",
      "colorType": "illustrations",
      "darkable": false,
      "id": "PassengerCategoryChecked"
    },
    "Psst": {
      "relative": "/colors/illustrations/Psst.svg",
      "absolute": "/atb/design-system/packages/assets/temp/colors/illustrations/Psst.svg",
      "assetType": "colors",
      "colorType": "illustrations",
      "darkable": false,
      "id": "Psst"
    },
    "badge/android": {
      "relative": "/colors/illustrations/badge/android.svg",
      "absolute": "/atb/design-system/packages/assets/temp/colors/illustrations/badge/android.svg",
      "assetType": "colors",
      "colorType": "illustrations",
      "darkable": false,
      "id": "badge/android"
    },
    "badge/ios": {
      "relative": "/colors/illustrations/badge/ios.svg",
      "absolute": "/atb/design-system/packages/assets/temp/colors/illustrations/badge/ios.svg",
      "assetType": "colors",
      "colorType": "illustrations",
      "darkable": false,
      "id": "badge/ios"
    },
    "token/mobile/Phone": {
      "relative": "/colors/illustrations/token/mobile/dark/Phone.svg",
      "absolute": "/atb/design-system/packages/assets/temp/colors/illustrations/token/mobile/dark/Phone.svg",
      "assetType": "colors",
      "colorType": "illustrations",
      "darkable": true,
      "id": "token/mobile/Phone"
    },
    "ticket-type/Boat": {
      "relative": "/colors/illustrations/ticket-type/dark/Boat.svg",
      "absolute": "/atb/design-system/packages/assets/temp/colors/illustrations/ticket-type/dark/Boat.svg",
      "assetType": "colors",
      "colorType": "illustrations",
      "darkable": true,
      "id": "ticket-type/Boat"
    },
    "ticket-type/Carnet": {
      "relative": "/colors/illustrations/ticket-type/dark/Carnet.svg",
      "absolute": "/atb/design-system/packages/assets/temp/colors/illustrations/ticket-type/dark/Carnet.svg",
      "assetType": "colors",
      "colorType": "illustrations",
      "darkable": true,
      "id": "ticket-type/Carnet"
    },
    "ticket-type/H24": {
      "relative": "/colors/illustrations/ticket-type/dark/H24.svg",
      "absolute": "/atb/design-system/packages/assets/temp/colors/illustrations/ticket-type/dark/H24.svg",
      "assetType": "colors",
      "colorType": "illustrations",
      "darkable": true,
      "id": "ticket-type/H24"
    },
    "ticket-type/Night": {
      "relative": "/colors/illustrations/ticket-type/dark/Night.svg",
      "absolute": "/atb/design-system/packages/assets/temp/colors/illustrations/ticket-type/dark/Night.svg",
      "assetType": "colors",
      "colorType": "illustrations",
      "darkable": true,
      "id": "ticket-type/Night"
    },
    "ticket-type/Period": {
      "relative": "/colors/illustrations/ticket-type/dark/Period.svg",
      "absolute": "/atb/design-system/packages/assets/temp/colors/illustrations/ticket-type/dark/Period.svg",
      "assetType": "colors",
      "colorType": "illustrations",
      "darkable": true,
      "id": "ticket-type/Period"
    },
    "ticket-type/Single": {
      "relative": "/colors/illustrations/ticket-type/dark/Single.svg",
      "absolute": "/atb/design-system/packages/assets/temp/colors/illustrations/ticket-type/dark/Single.svg",
      "assetType": "colors",
      "colorType": "illustrations",
      "darkable": true,
      "id": "ticket-type/Single"
    },
    "ticket-type/Summer": {
      "relative": "/colors/illustrations/ticket-type/dark/Summer.svg",
      "absolute": "/atb/design-system/packages/assets/temp/colors/illustrations/ticket-type/dark/Summer.svg",
      "assetType": "colors",
      "colorType": "illustrations",
      "darkable": true,
      "id": "ticket-type/Summer"
    },
    "ticket-type/Youth": {
      "relative": "/colors/illustrations/ticket-type/dark/Youth.svg",
      "absolute": "/atb/design-system/packages/assets/temp/colors/illustrations/ticket-type/dark/Youth.svg",
      "assetType": "colors",
      "colorType": "illustrations",
      "darkable": true,
      "id": "ticket-type/Youth"
    },
    "token/travelcard/Travelcard": {
      "relative": "/colors/illustrations/token/travelcard/dark/Travelcard.svg",
      "absolute": "/atb/design-system/packages/assets/temp/colors/illustrations/token/travelcard/dark/Travelcard.svg",
      "assetType": "colors",
      "colorType": "illustrations",
      "darkable": true,
      "id": "token/travelcard/Travelcard"
    }
  }
};
export type Icons = typeof icons;

export type MonoIcons = keyof Icons['mono'];
export type Images = keyof Icons['images'];
export type Illustrations = keyof Icons['illustration'];
```


</details>