### PR TITLE
fix: use alpha.7 as theme dependency instead of non-available alpha.8

### DIFF
--- a/packages/assets/package.json
+++ b/packages/assets/package.json
@@ -27,7 +27,7 @@
     "access": "public"
   },
   "dependencies": {
-    "@atb-as/theme": "^6.0.0-alpha.8",
+    "@atb-as/theme": "^6.0.0-alpha.7",
     "commander": "^9.4.0",
     "fast-glob": "^3.2.11",
     "micromatch": "^4.0.5",


### PR DESCRIPTION
Downgrading dependency, to one thats actually available on npm, after failing to publish alpha.8.