### PR TITLE
refactor: minor NFK token adjustments

### DIFF
--- a/packages/assets/files/nfk/colors/illustrations/token/travelcard/dark/Travelcard.svg
+++ b/packages/assets/files/nfk/colors/illustrations/token/travelcard/dark/Travelcard.svg
@@ -1,1 +1,0 @@
-<svg width="118" height="86" fill="none" xmlns="http://www.w3.org/2000/svg"/>

--- a/packages/assets/files/nfk/colors/illustrations/token/travelcard/light/Travelcard.svg
+++ b/packages/assets/files/nfk/colors/illustrations/token/travelcard/light/Travelcard.svg
@@ -1,1 +1,0 @@
-<svg width="118" height="86" fill="none" xmlns="http://www.w3.org/2000/svg"/>

--- a/packages/assets/files/nfk/colors/images/OnBehalfOf.svg
+++ b/packages/assets/files/nfk/colors/images/OnBehalfOf.svg
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<svg id="Kjøp_for_andre" data-name="Kjøp for andre" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 1571 1643">
+<svg width="165" height="131" id="Kjøp_for_andre" data-name="Kjøp for andre" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 1571 1643">
   <defs>
     <style>
       .cls-1 {


### PR DESCRIPTION
Related to https://github.com/AtB-AS/kundevendt/issues/2628

Includes for NFK:
- Size adjustment for on behalf of image, so it does not cover entire webshop2 page
- Removal of empty NFK specific travelcard illustration, so that the common illustration is used

Includes for AtB:
- Absolutely nothing
