### PR TITLE
fix: allow common assets files to be used if org file is not provided

### DIFF
--- a/packages/assets/src/tools/validate-files.ts
+++ b/packages/assets/src/tools/validate-files.ts
@@ -58,7 +58,7 @@ async function validateValidOrgs() {
     const diff = difference(expectedFiles.files, orgAssets.files);
 
     if (diff.length > 0) {
-      console.warn(
+      console.log(
         `${themeVariantAsString(
           orgAssets.org,
         )} seems to be missing some assets, checking if common files can be used for these files:\n${diff.join(

--- a/packages/assets/src/tools/validate-files.ts
+++ b/packages/assets/src/tools/validate-files.ts
@@ -19,11 +19,17 @@ async function fromOrgFiles(org: ThemeVariant) {
   return {org, files: files.map(cleanFilenames)};
 }
 
+async function exists(fileToCheck: string) {
+  return await promises
+    .access(fileToCheck, constants.F_OK)
+    .then(() => true)
+    .catch(() => false);
+}
+
 async function verifyThatMissingOrgFilesHasCommonReplacements(
   missingOrgFiles: string[],
 ) {
   let filesMissingFromBothOrgAndCommonFolder = <string[]>[];
-
   for (const missingOrgFile of missingOrgFiles) {
     const fullPath = path.join(
       __dirname,
@@ -33,16 +39,10 @@ async function verifyThatMissingOrgFilesHasCommonReplacements(
       'common',
       missingOrgFile,
     );
-    const commonFileExistsForMissingOrgFile = await promises
-      .access(fullPath, constants.F_OK)
-      .then(() => true)
-      .catch(() => false);
-
-    if (!commonFileExistsForMissingOrgFile) {
+    const missingOrgFileExistsInCommon = await exists(fullPath);
+    if (!missingOrgFileExistsInCommon)
       filesMissingFromBothOrgAndCommonFolder.push(fullPath);
-    }
   }
-
   return filesMissingFromBothOrgAndCommonFolder;
 }
 

--- a/packages/assets/src/tools/validate-files.ts
+++ b/packages/assets/src/tools/validate-files.ts
@@ -55,35 +55,34 @@ async function validateValidOrgs() {
   let hasErrors = false;
 
   for (let orgAssets of extraOrgs) {
-    const diff = difference(expectedFiles.files, orgAssets.files);
+    const filesMissingInOrg = difference(expectedFiles.files, orgAssets.files);
+    if (!filesMissingInOrg.length) continue;
 
-    if (diff.length > 0) {
-      console.log(
+    console.log(
+      `${themeVariantAsString(
+        orgAssets.org,
+      )} seems to be missing some assets, checking if common files can be used for these files:\n${filesMissingInOrg.join(
+        '\n',
+      )}`,
+    );
+    const filesMissingBothInOrgAndCommon =
+      await verifyThatMissingOrgFilesHasCommonReplacements(filesMissingInOrg);
+
+    if (filesMissingBothInOrgAndCommon.length) {
+      hasErrors = true;
+      console.error(
         `${themeVariantAsString(
           orgAssets.org,
-        )} seems to be missing some assets, checking if common files can be used for these files:\n${diff.join(
+        )} is missing some assets, that also does not have a common file:\n${filesMissingBothInOrgAndCommon.join(
           '\n',
         )}`,
       );
-      const filesMissingBothInOrgAndCommon =
-        await verifyThatMissingOrgFilesHasCommonReplacements(diff);
-
-      if (filesMissingBothInOrgAndCommon.length) {
-        hasErrors = true;
-        console.error(
-          `${themeVariantAsString(
-            orgAssets.org,
-          )} is missing some assets, that also does not have a common file:\n${filesMissingBothInOrgAndCommon.join(
-            '\n',
-          )}`,
-        );
-      }
     }
   }
 
-  if (hasErrors) {
-    process.exit(1);
-  }
+  hasErrors
+    ? process.exit(1)
+    : console.log('Asset validation completed successfully');
 }
 
 function cleanFilenames(filename: string) {

--- a/packages/assets/src/tools/validate-files.ts
+++ b/packages/assets/src/tools/validate-files.ts
@@ -71,12 +71,11 @@ async function validateValidOrgs() {
       if (filesMissingBothInOrgAndCommon.length) {
         hasErrors = true;
         console.error(
-          `
-                ${themeVariantAsString(
-                  orgAssets.org,
-                )} is missing some assets, that also does not have a common file:
-                ${filesMissingBothInOrgAndCommon.join('\n')}
-              `,
+          `${themeVariantAsString(
+            orgAssets.org,
+          )} is missing some assets, that also does not have a common file:\n${filesMissingBothInOrgAndCommon.join(
+            '\n',
+          )}`,
         );
       }
     }


### PR DESCRIPTION
In the event of an org providing an org-specific asset file for something other organization uses a common file for, the validation of asset files now fails. An example of this is the travelcard asset, where AtB has provided their own t:kort illustration asset.

This pull requests makes the validation script check if a replacement file exists in the common folder, and only returns the exit code 1 if there is no common file.
