### PR TITLE
feat: add airport express theme color

### DIFF
--- a/packages/theme/src/theme.ts
+++ b/packages/theme/src/theme.ts
@@ -71,8 +71,8 @@ export interface Theme {
 
     zone_selection: {
       from: ContrastColor;
-      to: ContrastColor
-    }
+      to: ContrastColor;
+    };
   };
 
   text: {

--- a/packages/theme/src/theme.ts
+++ b/packages/theme/src/theme.ts
@@ -54,6 +54,7 @@ export interface Theme {
     transport: {
       transport_city: ContrastColor;
       transport_region: ContrastColor;
+      transport_airport_express: ContrastColor;
       transport_boat: ContrastColor;
       transport_train: ContrastColor;
       transport_airport: ContrastColor;

--- a/packages/theme/src/themes/atb-theme/theme.css
+++ b/packages/theme/src/themes/atb-theme/theme.css
@@ -49,6 +49,8 @@
   --static-transport-transport_city-text: #000000;
   --static-transport-transport_region-background: #007C92;
   --static-transport-transport_region-text: #FFFFFF;
+  --static-transport-transport_airport_express-background: #A51140;
+  --static-transport-transport_airport_express-text: #FFFFFF;
   --static-transport-transport_boat-background: #71D6E0;
   --static-transport-transport_boat-text: #000000;
   --static-transport-transport_train-background: #4B2942;
@@ -184,6 +186,8 @@
   --static-transport-transport_city-text: #000000;
   --static-transport-transport_region-background: #007C92;
   --static-transport-transport_region-text: #FFFFFF;
+  --static-transport-transport_airport_express-background: #A51140;
+  --static-transport-transport_airport_express-text: #FFFFFF;
   --static-transport-transport_boat-background: #71D6E0;
   --static-transport-transport_boat-text: #000000;
   --static-transport-transport_train-background: #4B2942;
@@ -319,6 +323,8 @@
   --static-transport-transport_city-text: #000000;
   --static-transport-transport_region-background: #007C92;
   --static-transport-transport_region-text: #FFFFFF;
+  --static-transport-transport_airport_express-background: #A51140;
+  --static-transport-transport_airport_express-text: #FFFFFF;
   --static-transport-transport_boat-background: #71D6E0;
   --static-transport-transport_boat-text: #000000;
   --static-transport-transport_train-background: #4B2942;
@@ -454,6 +460,10 @@
 .static-transport-transport_region {
   background-color: var(--static-transport-transport_region-background);
   color: var(--static-transport-transport_region-text);
+}
+.static-transport-transport_airport_express {
+  background-color: var(--static-transport-transport_airport_express-background);
+  color: var(--static-transport-transport_airport_express-text);
 }
 .static-transport-transport_boat {
   background-color: var(--static-transport-transport_boat-background);

--- a/packages/theme/src/themes/atb-theme/theme.module.css
+++ b/packages/theme/src/themes/atb-theme/theme.module.css
@@ -49,6 +49,8 @@
   --static-transport-transport_city-text: #000000;
   --static-transport-transport_region-background: #007C92;
   --static-transport-transport_region-text: #FFFFFF;
+  --static-transport-transport_airport_express-background: #A51140;
+  --static-transport-transport_airport_express-text: #FFFFFF;
   --static-transport-transport_boat-background: #71D6E0;
   --static-transport-transport_boat-text: #000000;
   --static-transport-transport_train-background: #4B2942;
@@ -184,6 +186,8 @@
   --static-transport-transport_city-text: #000000;
   --static-transport-transport_region-background: #007C92;
   --static-transport-transport_region-text: #FFFFFF;
+  --static-transport-transport_airport_express-background: #A51140;
+  --static-transport-transport_airport_express-text: #FFFFFF;
   --static-transport-transport_boat-background: #71D6E0;
   --static-transport-transport_boat-text: #000000;
   --static-transport-transport_train-background: #4B2942;
@@ -319,6 +323,8 @@
   --static-transport-transport_city-text: #000000;
   --static-transport-transport_region-background: #007C92;
   --static-transport-transport_region-text: #FFFFFF;
+  --static-transport-transport_airport_express-background: #A51140;
+  --static-transport-transport_airport_express-text: #FFFFFF;
   --static-transport-transport_boat-background: #71D6E0;
   --static-transport-transport_boat-text: #000000;
   --static-transport-transport_train-background: #4B2942;
@@ -454,6 +460,10 @@
 .static-transport-transport_region {
   background-color: var(--static-transport-transport_region-background);
   color: var(--static-transport-transport_region-text);
+}
+.static-transport-transport_airport_express {
+  background-color: var(--static-transport-transport_airport_express-background);
+  color: var(--static-transport-transport_airport_express-text);
 }
 .static-transport-transport_boat {
   background-color: var(--static-transport-transport_boat-background);

--- a/packages/theme/src/themes/atb-theme/theme.ts
+++ b/packages/theme/src/themes/atb-theme/theme.ts
@@ -199,6 +199,7 @@ const themes: Themes = {
       transport: {
         transport_city: baseColors.green_300,
         transport_region: baseColors.blue_500,
+        transport_airport_express: baseColors.red_600,
         transport_boat: baseColors.cyan_200,
         transport_train: baseColors.burgundy_800,
         transport_airport: baseColors.orange_500,
@@ -297,6 +298,7 @@ const themes: Themes = {
       transport: {
         transport_city: baseColors.green_300,
         transport_region: baseColors.blue_500,
+        transport_airport_express: baseColors.red_600,
         transport_boat: baseColors.cyan_200,
         transport_train: baseColors.burgundy_800,
         transport_airport: baseColors.orange_500,

--- a/packages/theme/src/themes/atb-theme/theme.ts
+++ b/packages/theme/src/themes/atb-theme/theme.ts
@@ -214,8 +214,8 @@ const themes: Themes = {
       },
       zone_selection: {
         from: baseColors.green_300,
-        to: baseColors.cyan_200
-      }
+        to: baseColors.cyan_200,
+      },
     },
 
     text: {
@@ -313,8 +313,8 @@ const themes: Themes = {
       },
       zone_selection: {
         from: baseColors.green_300,
-        to: baseColors.cyan_200
-      }
+        to: baseColors.cyan_200,
+      },
     },
     text: {
       colors: {

--- a/packages/theme/src/themes/fram-theme/theme.css
+++ b/packages/theme/src/themes/fram-theme/theme.css
@@ -49,6 +49,8 @@
   --static-transport-transport_city-text: #000000;
   --static-transport-transport_region-background: #005685;
   --static-transport-transport_region-text: #FFFFFF;
+  --static-transport-transport_airport_express-background: #82B962;
+  --static-transport-transport_airport_express-text: #000000;
   --static-transport-transport_boat-background: #007FBA;
   --static-transport-transport_boat-text: #FFFFFF;
   --static-transport-transport_train-background: #551125;
@@ -184,6 +186,8 @@
   --static-transport-transport_city-text: #000000;
   --static-transport-transport_region-background: #005685;
   --static-transport-transport_region-text: #FFFFFF;
+  --static-transport-transport_airport_express-background: #82B962;
+  --static-transport-transport_airport_express-text: #000000;
   --static-transport-transport_boat-background: #007FBA;
   --static-transport-transport_boat-text: #FFFFFF;
   --static-transport-transport_train-background: #551125;
@@ -319,6 +323,8 @@
   --static-transport-transport_city-text: #000000;
   --static-transport-transport_region-background: #005685;
   --static-transport-transport_region-text: #FFFFFF;
+  --static-transport-transport_airport_express-background: #82B962;
+  --static-transport-transport_airport_express-text: #000000;
   --static-transport-transport_boat-background: #007FBA;
   --static-transport-transport_boat-text: #FFFFFF;
   --static-transport-transport_train-background: #551125;
@@ -454,6 +460,10 @@
 .static-transport-transport_region {
   background-color: var(--static-transport-transport_region-background);
   color: var(--static-transport-transport_region-text);
+}
+.static-transport-transport_airport_express {
+  background-color: var(--static-transport-transport_airport_express-background);
+  color: var(--static-transport-transport_airport_express-text);
 }
 .static-transport-transport_boat {
   background-color: var(--static-transport-transport_boat-background);

--- a/packages/theme/src/themes/fram-theme/theme.css
+++ b/packages/theme/src/themes/fram-theme/theme.css
@@ -49,8 +49,8 @@
   --static-transport-transport_city-text: #000000;
   --static-transport-transport_region-background: #005685;
   --static-transport-transport_region-text: #FFFFFF;
-  --static-transport-transport_airport_express-background: #82B962;
-  --static-transport-transport_airport_express-text: #000000;
+  --static-transport-transport_airport_express-background: #005685;
+  --static-transport-transport_airport_express-text: #FFFFFF;
   --static-transport-transport_boat-background: #007FBA;
   --static-transport-transport_boat-text: #FFFFFF;
   --static-transport-transport_train-background: #551125;
@@ -186,8 +186,8 @@
   --static-transport-transport_city-text: #000000;
   --static-transport-transport_region-background: #005685;
   --static-transport-transport_region-text: #FFFFFF;
-  --static-transport-transport_airport_express-background: #82B962;
-  --static-transport-transport_airport_express-text: #000000;
+  --static-transport-transport_airport_express-background: #005685;
+  --static-transport-transport_airport_express-text: #FFFFFF;
   --static-transport-transport_boat-background: #007FBA;
   --static-transport-transport_boat-text: #FFFFFF;
   --static-transport-transport_train-background: #551125;
@@ -323,8 +323,8 @@
   --static-transport-transport_city-text: #000000;
   --static-transport-transport_region-background: #005685;
   --static-transport-transport_region-text: #FFFFFF;
-  --static-transport-transport_airport_express-background: #82B962;
-  --static-transport-transport_airport_express-text: #000000;
+  --static-transport-transport_airport_express-background: #005685;
+  --static-transport-transport_airport_express-text: #FFFFFF;
   --static-transport-transport_boat-background: #007FBA;
   --static-transport-transport_boat-text: #FFFFFF;
   --static-transport-transport_train-background: #551125;

--- a/packages/theme/src/themes/fram-theme/theme.module.css
+++ b/packages/theme/src/themes/fram-theme/theme.module.css
@@ -49,6 +49,8 @@
   --static-transport-transport_city-text: #000000;
   --static-transport-transport_region-background: #005685;
   --static-transport-transport_region-text: #FFFFFF;
+  --static-transport-transport_airport_express-background: #82B962;
+  --static-transport-transport_airport_express-text: #000000;
   --static-transport-transport_boat-background: #007FBA;
   --static-transport-transport_boat-text: #FFFFFF;
   --static-transport-transport_train-background: #551125;
@@ -184,6 +186,8 @@
   --static-transport-transport_city-text: #000000;
   --static-transport-transport_region-background: #005685;
   --static-transport-transport_region-text: #FFFFFF;
+  --static-transport-transport_airport_express-background: #82B962;
+  --static-transport-transport_airport_express-text: #000000;
   --static-transport-transport_boat-background: #007FBA;
   --static-transport-transport_boat-text: #FFFFFF;
   --static-transport-transport_train-background: #551125;
@@ -319,6 +323,8 @@
   --static-transport-transport_city-text: #000000;
   --static-transport-transport_region-background: #005685;
   --static-transport-transport_region-text: #FFFFFF;
+  --static-transport-transport_airport_express-background: #82B962;
+  --static-transport-transport_airport_express-text: #000000;
   --static-transport-transport_boat-background: #007FBA;
   --static-transport-transport_boat-text: #FFFFFF;
   --static-transport-transport_train-background: #551125;
@@ -454,6 +460,10 @@
 .static-transport-transport_region {
   background-color: var(--static-transport-transport_region-background);
   color: var(--static-transport-transport_region-text);
+}
+.static-transport-transport_airport_express {
+  background-color: var(--static-transport-transport_airport_express-background);
+  color: var(--static-transport-transport_airport_express-text);
 }
 .static-transport-transport_boat {
   background-color: var(--static-transport-transport_boat-background);

--- a/packages/theme/src/themes/fram-theme/theme.module.css
+++ b/packages/theme/src/themes/fram-theme/theme.module.css
@@ -49,8 +49,8 @@
   --static-transport-transport_city-text: #000000;
   --static-transport-transport_region-background: #005685;
   --static-transport-transport_region-text: #FFFFFF;
-  --static-transport-transport_airport_express-background: #82B962;
-  --static-transport-transport_airport_express-text: #000000;
+  --static-transport-transport_airport_express-background: #005685;
+  --static-transport-transport_airport_express-text: #FFFFFF;
   --static-transport-transport_boat-background: #007FBA;
   --static-transport-transport_boat-text: #FFFFFF;
   --static-transport-transport_train-background: #551125;
@@ -186,8 +186,8 @@
   --static-transport-transport_city-text: #000000;
   --static-transport-transport_region-background: #005685;
   --static-transport-transport_region-text: #FFFFFF;
-  --static-transport-transport_airport_express-background: #82B962;
-  --static-transport-transport_airport_express-text: #000000;
+  --static-transport-transport_airport_express-background: #005685;
+  --static-transport-transport_airport_express-text: #FFFFFF;
   --static-transport-transport_boat-background: #007FBA;
   --static-transport-transport_boat-text: #FFFFFF;
   --static-transport-transport_train-background: #551125;
@@ -323,8 +323,8 @@
   --static-transport-transport_city-text: #000000;
   --static-transport-transport_region-background: #005685;
   --static-transport-transport_region-text: #FFFFFF;
-  --static-transport-transport_airport_express-background: #82B962;
-  --static-transport-transport_airport_express-text: #000000;
+  --static-transport-transport_airport_express-background: #005685;
+  --static-transport-transport_airport_express-text: #FFFFFF;
   --static-transport-transport_boat-background: #007FBA;
   --static-transport-transport_boat-text: #FFFFFF;
   --static-transport-transport_train-background: #551125;

--- a/packages/theme/src/themes/fram-theme/theme.ts
+++ b/packages/theme/src/themes/fram-theme/theme.ts
@@ -77,6 +77,7 @@ const themes: Themes = {
       transport: {
         transport_city: contrastColor('#82B962', 'dark'),
         transport_region: contrastColor('#005685', 'light'),
+        transport_airport_express: contrastColor('#82B962', 'dark'),
         transport_boat: contrastColor('#007FBA', 'light'),
         transport_train: contrastColor('#551125', 'light'),
         transport_airport: contrastColor('#F15659', 'light'),
@@ -174,6 +175,7 @@ const themes: Themes = {
       transport: {
         transport_city: contrastColor('#82B962', 'dark'),
         transport_region: contrastColor('#005685', 'light'),
+        transport_airport_express: contrastColor('#82B962', 'dark'),
         transport_boat: contrastColor('#007FBA', 'light'),
         transport_train: contrastColor('#551125', 'light'),
         transport_airport: contrastColor('#F15659', 'light'),

--- a/packages/theme/src/themes/fram-theme/theme.ts
+++ b/packages/theme/src/themes/fram-theme/theme.ts
@@ -92,8 +92,8 @@ const themes: Themes = {
       },
       zone_selection: {
         from: contrastColor('#82B962', 'dark'),
-        to: contrastColor('#005685', 'light')
-      }
+        to: contrastColor('#005685', 'light'),
+      },
     },
 
     text: {
@@ -190,8 +190,8 @@ const themes: Themes = {
       },
       zone_selection: {
         from: contrastColor('#82B962', 'dark'),
-        to: contrastColor('#005685', 'light')
-      }
+        to: contrastColor('#005685', 'light'),
+      },
     },
     text: {
       colors: {

--- a/packages/theme/src/themes/fram-theme/theme.ts
+++ b/packages/theme/src/themes/fram-theme/theme.ts
@@ -77,7 +77,7 @@ const themes: Themes = {
       transport: {
         transport_city: contrastColor('#82B962', 'dark'),
         transport_region: contrastColor('#005685', 'light'),
-        transport_airport_express: contrastColor('#82B962', 'dark'),
+        transport_airport_express: contrastColor('#005685', 'light'),
         transport_boat: contrastColor('#007FBA', 'light'),
         transport_train: contrastColor('#551125', 'light'),
         transport_airport: contrastColor('#F15659', 'light'),
@@ -175,7 +175,7 @@ const themes: Themes = {
       transport: {
         transport_city: contrastColor('#82B962', 'dark'),
         transport_region: contrastColor('#005685', 'light'),
-        transport_airport_express: contrastColor('#82B962', 'dark'),
+        transport_airport_express: contrastColor('#005685', 'light'),
         transport_boat: contrastColor('#007FBA', 'light'),
         transport_train: contrastColor('#551125', 'light'),
         transport_airport: contrastColor('#F15659', 'light'),

--- a/packages/theme/src/themes/nfk-theme/theme.css
+++ b/packages/theme/src/themes/nfk-theme/theme.css
@@ -49,6 +49,8 @@
   --static-transport-transport_city-text: #FFFFFF;
   --static-transport-transport_region-background: #6C7E2F;
   --static-transport-transport_region-text: #FFFFFF;
+  --static-transport-transport_airport_express-background: #014D61;
+  --static-transport-transport_airport_express-text: #FFFFFF;
   --static-transport-transport_boat-background: #1777D7;
   --static-transport-transport_boat-text: #FFFFFF;
   --static-transport-transport_train-background: #A5608A;
@@ -184,6 +186,8 @@
   --static-transport-transport_city-text: #003441;
   --static-transport-transport_region-background: #98A56D;
   --static-transport-transport_region-text: #003441;
+  --static-transport-transport_airport_express-background: #80C0D1;
+  --static-transport-transport_airport_express-text: #003441;
   --static-transport-transport_boat-background: #5DA0E3;
   --static-transport-transport_boat-text: #003441;
   --static-transport-transport_train-background: #C090AD;
@@ -319,6 +323,8 @@
   --static-transport-transport_city-text: #003441;
   --static-transport-transport_region-background: #98A56D;
   --static-transport-transport_region-text: #003441;
+  --static-transport-transport_airport_express-background: #80C0D1;
+  --static-transport-transport_airport_express-text: #003441;
   --static-transport-transport_boat-background: #5DA0E3;
   --static-transport-transport_boat-text: #003441;
   --static-transport-transport_train-background: #C090AD;
@@ -454,6 +460,10 @@
 .static-transport-transport_region {
   background-color: var(--static-transport-transport_region-background);
   color: var(--static-transport-transport_region-text);
+}
+.static-transport-transport_airport_express {
+  background-color: var(--static-transport-transport_airport_express-background);
+  color: var(--static-transport-transport_airport_express-text);
 }
 .static-transport-transport_boat {
   background-color: var(--static-transport-transport_boat-background);

--- a/packages/theme/src/themes/nfk-theme/theme.css
+++ b/packages/theme/src/themes/nfk-theme/theme.css
@@ -49,7 +49,7 @@
   --static-transport-transport_city-text: #FFFFFF;
   --static-transport-transport_region-background: #6C7E2F;
   --static-transport-transport_region-text: #FFFFFF;
-  --static-transport-transport_airport_express-background: #014D61;
+  --static-transport-transport_airport_express-background: #6C7E2F;
   --static-transport-transport_airport_express-text: #FFFFFF;
   --static-transport-transport_boat-background: #1777D7;
   --static-transport-transport_boat-text: #FFFFFF;
@@ -186,7 +186,7 @@
   --static-transport-transport_city-text: #003441;
   --static-transport-transport_region-background: #98A56D;
   --static-transport-transport_region-text: #003441;
-  --static-transport-transport_airport_express-background: #80C0D1;
+  --static-transport-transport_airport_express-background: #98A56D;
   --static-transport-transport_airport_express-text: #003441;
   --static-transport-transport_boat-background: #5DA0E3;
   --static-transport-transport_boat-text: #003441;
@@ -323,7 +323,7 @@
   --static-transport-transport_city-text: #003441;
   --static-transport-transport_region-background: #98A56D;
   --static-transport-transport_region-text: #003441;
-  --static-transport-transport_airport_express-background: #80C0D1;
+  --static-transport-transport_airport_express-background: #98A56D;
   --static-transport-transport_airport_express-text: #003441;
   --static-transport-transport_boat-background: #5DA0E3;
   --static-transport-transport_boat-text: #003441;

--- a/packages/theme/src/themes/nfk-theme/theme.module.css
+++ b/packages/theme/src/themes/nfk-theme/theme.module.css
@@ -49,6 +49,8 @@
   --static-transport-transport_city-text: #FFFFFF;
   --static-transport-transport_region-background: #6C7E2F;
   --static-transport-transport_region-text: #FFFFFF;
+  --static-transport-transport_airport_express-background: #014D61;
+  --static-transport-transport_airport_express-text: #FFFFFF;
   --static-transport-transport_boat-background: #1777D7;
   --static-transport-transport_boat-text: #FFFFFF;
   --static-transport-transport_train-background: #A5608A;
@@ -184,6 +186,8 @@
   --static-transport-transport_city-text: #003441;
   --static-transport-transport_region-background: #98A56D;
   --static-transport-transport_region-text: #003441;
+  --static-transport-transport_airport_express-background: #80C0D1;
+  --static-transport-transport_airport_express-text: #003441;
   --static-transport-transport_boat-background: #5DA0E3;
   --static-transport-transport_boat-text: #003441;
   --static-transport-transport_train-background: #C090AD;
@@ -319,6 +323,8 @@
   --static-transport-transport_city-text: #003441;
   --static-transport-transport_region-background: #98A56D;
   --static-transport-transport_region-text: #003441;
+  --static-transport-transport_airport_express-background: #80C0D1;
+  --static-transport-transport_airport_express-text: #003441;
   --static-transport-transport_boat-background: #5DA0E3;
   --static-transport-transport_boat-text: #003441;
   --static-transport-transport_train-background: #C090AD;
@@ -454,6 +460,10 @@
 .static-transport-transport_region {
   background-color: var(--static-transport-transport_region-background);
   color: var(--static-transport-transport_region-text);
+}
+.static-transport-transport_airport_express {
+  background-color: var(--static-transport-transport_airport_express-background);
+  color: var(--static-transport-transport_airport_express-text);
 }
 .static-transport-transport_boat {
   background-color: var(--static-transport-transport_boat-background);

--- a/packages/theme/src/themes/nfk-theme/theme.module.css
+++ b/packages/theme/src/themes/nfk-theme/theme.module.css
@@ -49,7 +49,7 @@
   --static-transport-transport_city-text: #FFFFFF;
   --static-transport-transport_region-background: #6C7E2F;
   --static-transport-transport_region-text: #FFFFFF;
-  --static-transport-transport_airport_express-background: #014D61;
+  --static-transport-transport_airport_express-background: #6C7E2F;
   --static-transport-transport_airport_express-text: #FFFFFF;
   --static-transport-transport_boat-background: #1777D7;
   --static-transport-transport_boat-text: #FFFFFF;
@@ -186,7 +186,7 @@
   --static-transport-transport_city-text: #003441;
   --static-transport-transport_region-background: #98A56D;
   --static-transport-transport_region-text: #003441;
-  --static-transport-transport_airport_express-background: #80C0D1;
+  --static-transport-transport_airport_express-background: #98A56D;
   --static-transport-transport_airport_express-text: #003441;
   --static-transport-transport_boat-background: #5DA0E3;
   --static-transport-transport_boat-text: #003441;
@@ -323,7 +323,7 @@
   --static-transport-transport_city-text: #003441;
   --static-transport-transport_region-background: #98A56D;
   --static-transport-transport_region-text: #003441;
-  --static-transport-transport_airport_express-background: #80C0D1;
+  --static-transport-transport_airport_express-background: #98A56D;
   --static-transport-transport_airport_express-text: #003441;
   --static-transport-transport_boat-background: #5DA0E3;
   --static-transport-transport_boat-text: #003441;

--- a/packages/theme/src/themes/nfk-theme/theme.ts
+++ b/packages/theme/src/themes/nfk-theme/theme.ts
@@ -82,6 +82,7 @@ const themes: Themes = {
       transport: {
         transport_city: contrastColor('#014D61', 'light'),
         transport_region: contrastColor('#6C7E2F', 'light'),
+        transport_airport_express: contrastColor('#014D61', 'light'),
         transport_boat: contrastColor('#1777D7', 'light'),
         transport_train: contrastColor('#A5608A', 'light'),
         transport_airport: contrastColor('#8A62C3', 'light'),
@@ -178,6 +179,7 @@ const themes: Themes = {
       transport: {
         transport_city: contrastColor('#80C0D1'),
         transport_region: contrastColor('#98A56D'),
+        transport_airport_express: contrastColor('#80C0D1'),
         transport_boat: contrastColor('#5DA0E3'),
         transport_train: contrastColor('#C090AD'),
         transport_airport: contrastColor('#AD91D5'),

--- a/packages/theme/src/themes/nfk-theme/theme.ts
+++ b/packages/theme/src/themes/nfk-theme/theme.ts
@@ -82,7 +82,7 @@ const themes: Themes = {
       transport: {
         transport_city: contrastColor('#014D61', 'light'),
         transport_region: contrastColor('#6C7E2F', 'light'),
-        transport_airport_express: contrastColor('#014D61', 'light'),
+        transport_airport_express: contrastColor('#6C7E2F', 'light'),
         transport_boat: contrastColor('#1777D7', 'light'),
         transport_train: contrastColor('#A5608A', 'light'),
         transport_airport: contrastColor('#8A62C3', 'light'),
@@ -179,7 +179,7 @@ const themes: Themes = {
       transport: {
         transport_city: contrastColor('#80C0D1'),
         transport_region: contrastColor('#98A56D'),
-        transport_airport_express: contrastColor('#80C0D1'),
+        transport_airport_express: contrastColor('#98A56D'),
         transport_boat: contrastColor('#5DA0E3'),
         transport_train: contrastColor('#C090AD'),
         transport_airport: contrastColor('#AD91D5'),

--- a/packages/theme/src/themes/nfk-theme/theme.ts
+++ b/packages/theme/src/themes/nfk-theme/theme.ts
@@ -97,8 +97,8 @@ const themes: Themes = {
       },
       zone_selection: {
         from: contrastColor('#FF7E81', 'dark'),
-        to: contrastColor('#FF282E', 'light')
-      }
+        to: contrastColor('#FF282E', 'light'),
+      },
     },
 
     text: {
@@ -194,8 +194,8 @@ const themes: Themes = {
       },
       zone_selection: {
         from: contrastColor('#FF7E81', 'dark'),
-        to: contrastColor('#FF282E', 'light')
-      }
+        to: contrastColor('#FF282E', 'light'),
+      },
     },
     text: {
       colors: {


### PR DESCRIPTION
https://github.com/AtB-AS/kundevendt/issues/2832

Adds airport express transport color. For FRAM/NFK, I just copied the regional bus colors, so there shouldn't be any difference there.