### PR TITLE
refactor: update interactive 0 color for fram in dark mode

### DIFF
--- a/packages/theme/src/themes/fram-theme/theme.css
+++ b/packages/theme/src/themes/fram-theme/theme.css
@@ -215,10 +215,10 @@
   --static-zone_selection-to-background: #005685;
   --static-zone_selection-to-text: #FFFFFF;
 
-  --interactive-interactive_0-default-background: #76A4C0;
-  --interactive-interactive_0-default-text: #000000;
-  --interactive-interactive_0-hover-background: #AAC6D8;
-  --interactive-interactive_0-hover-text: #000000;
+  --interactive-interactive_0-default-background: #005685;
+  --interactive-interactive_0-default-text: #FFFFFF;
+  --interactive-interactive_0-hover-background: #007FBA;
+  --interactive-interactive_0-hover-text: #FFFFFF;
   --interactive-interactive_0-active-background: #CDE9E3;
   --interactive-interactive_0-active-text: #000000;
   --interactive-interactive_0-disabled-background: #C7CACC;
@@ -354,10 +354,10 @@
   --static-zone_selection-to-background: #005685;
   --static-zone_selection-to-text: #FFFFFF;
 
-  --interactive-interactive_0-default-background: #76A4C0;
-  --interactive-interactive_0-default-text: #000000;
-  --interactive-interactive_0-hover-background: #AAC6D8;
-  --interactive-interactive_0-hover-text: #000000;
+  --interactive-interactive_0-default-background: #005685;
+  --interactive-interactive_0-default-text: #FFFFFF;
+  --interactive-interactive_0-hover-background: #007FBA;
+  --interactive-interactive_0-hover-text: #FFFFFF;
   --interactive-interactive_0-active-background: #CDE9E3;
   --interactive-interactive_0-active-text: #000000;
   --interactive-interactive_0-disabled-background: #C7CACC;

--- a/packages/theme/src/themes/fram-theme/theme.module.css
+++ b/packages/theme/src/themes/fram-theme/theme.module.css
@@ -215,10 +215,10 @@
   --static-zone_selection-to-background: #005685;
   --static-zone_selection-to-text: #FFFFFF;
 
-  --interactive-interactive_0-default-background: #76A4C0;
-  --interactive-interactive_0-default-text: #000000;
-  --interactive-interactive_0-hover-background: #AAC6D8;
-  --interactive-interactive_0-hover-text: #000000;
+  --interactive-interactive_0-default-background: #005685;
+  --interactive-interactive_0-default-text: #FFFFFF;
+  --interactive-interactive_0-hover-background: #007FBA;
+  --interactive-interactive_0-hover-text: #FFFFFF;
   --interactive-interactive_0-active-background: #CDE9E3;
   --interactive-interactive_0-active-text: #000000;
   --interactive-interactive_0-disabled-background: #C7CACC;
@@ -354,10 +354,10 @@
   --static-zone_selection-to-background: #005685;
   --static-zone_selection-to-text: #FFFFFF;
 
-  --interactive-interactive_0-default-background: #76A4C0;
-  --interactive-interactive_0-default-text: #000000;
-  --interactive-interactive_0-hover-background: #AAC6D8;
-  --interactive-interactive_0-hover-text: #000000;
+  --interactive-interactive_0-default-background: #005685;
+  --interactive-interactive_0-default-text: #FFFFFF;
+  --interactive-interactive_0-hover-background: #007FBA;
+  --interactive-interactive_0-hover-text: #FFFFFF;
   --interactive-interactive_0-active-background: #CDE9E3;
   --interactive-interactive_0-active-text: #000000;
   --interactive-interactive_0-disabled-background: #C7CACC;

--- a/packages/theme/src/themes/fram-theme/theme.ts
+++ b/packages/theme/src/themes/fram-theme/theme.ts
@@ -119,8 +119,8 @@ const themes: Themes = {
     spacings: spacings,
     interactive: {
       interactive_0: {
-        default: contrastColor('#76A4C0', 'dark'),
-        hover: contrastColor('#AAC6D8', 'dark'),
+        default: contrastColor('#005685', 'light'),
+        hover: contrastColor('#007FBA', 'light'),
         active: contrastColor('#CDE9E3', 'dark'),
         disabled: contrastColor('#C7CACC', 'dark'),
         outline: contrastColor('#0D6569', 'light'),


### PR DESCRIPTION
Related to https://github.com/AtB-AS/kundevendt/issues/3585

The color for interactive 0 in dark mode was changed earlier to fit better with the background illustration. As the illustration is removed I've changed it back to the original colors. By doing so, we also fix the issue with the wrong icon color. 