### PR TITLE
feat: new blue color for FRAM

### DIFF
--- a/packages/theme/src/themes/fram-theme/theme.css
+++ b/packages/theme/src/themes/fram-theme/theme.css
@@ -33,7 +33,7 @@
   --static-background-background_2-text: #000000;
   --static-background-background_3-background: #D5D7D9;
   --static-background-background_3-text: #000000;
-  --static-background-background_accent_0-background: #027FAF;
+  --static-background-background_accent_0-background: #007AB5;
   --static-background-background_accent_0-text: #FFFFFF;
   --static-background-background_accent_1-background: #006594;
   --static-background-background_accent_1-text: #FFFFFF;
@@ -43,7 +43,7 @@
   --static-background-background_accent_3-text: #FFFFFF;
   --static-background-background_accent_4-background: #F0E991;
   --static-background-background_accent_4-text: #000000;
-  --static-background-background_accent_5-background: #027FAF;
+  --static-background-background_accent_5-background: #007AB5;
   --static-background-background_accent_5-text: #FFFFFF;
   --static-transport-transport_city-background: #82B962;
   --static-transport-transport_city-text: #000000;
@@ -78,7 +78,7 @@
 
   --interactive-interactive_0-default-background: #005685;
   --interactive-interactive_0-default-text: #FFFFFF;
-  --interactive-interactive_0-hover-background: #027FAF;
+  --interactive-interactive_0-hover-background: #007AB5;
   --interactive-interactive_0-hover-text: #FFFFFF;
   --interactive-interactive_0-active-background: #CDE9E3;
   --interactive-interactive_0-active-text: #000000;
@@ -172,7 +172,7 @@
   --static-background-background_2-text: #FFFFFF;
   --static-background-background_3-background: #555E65;
   --static-background-background_3-text: #FFFFFF;
-  --static-background-background_accent_0-background: #027FAF;
+  --static-background-background_accent_0-background: #007AB5;
   --static-background-background_accent_0-text: #FFFFFF;
   --static-background-background_accent_1-background: #006594;
   --static-background-background_accent_1-text: #FFFFFF;
@@ -182,7 +182,7 @@
   --static-background-background_accent_3-text: #FFFFFF;
   --static-background-background_accent_4-background: #F0E991;
   --static-background-background_accent_4-text: #000000;
-  --static-background-background_accent_5-background: #027FAF;
+  --static-background-background_accent_5-background: #007AB5;
   --static-background-background_accent_5-text: #FFFFFF;
   --static-transport-transport_city-background: #82B962;
   --static-transport-transport_city-text: #000000;
@@ -217,7 +217,7 @@
 
   --interactive-interactive_0-default-background: #005685;
   --interactive-interactive_0-default-text: #FFFFFF;
-  --interactive-interactive_0-hover-background: #027FAF;
+  --interactive-interactive_0-hover-background: #007AB5;
   --interactive-interactive_0-hover-text: #FFFFFF;
   --interactive-interactive_0-active-background: #CDE9E3;
   --interactive-interactive_0-active-text: #000000;
@@ -311,7 +311,7 @@
   --static-background-background_2-text: #FFFFFF;
   --static-background-background_3-background: #555E65;
   --static-background-background_3-text: #FFFFFF;
-  --static-background-background_accent_0-background: #027FAF;
+  --static-background-background_accent_0-background: #007AB5;
   --static-background-background_accent_0-text: #FFFFFF;
   --static-background-background_accent_1-background: #006594;
   --static-background-background_accent_1-text: #FFFFFF;
@@ -321,7 +321,7 @@
   --static-background-background_accent_3-text: #FFFFFF;
   --static-background-background_accent_4-background: #F0E991;
   --static-background-background_accent_4-text: #000000;
-  --static-background-background_accent_5-background: #027FAF;
+  --static-background-background_accent_5-background: #007AB5;
   --static-background-background_accent_5-text: #FFFFFF;
   --static-transport-transport_city-background: #82B962;
   --static-transport-transport_city-text: #000000;
@@ -356,7 +356,7 @@
 
   --interactive-interactive_0-default-background: #005685;
   --interactive-interactive_0-default-text: #FFFFFF;
-  --interactive-interactive_0-hover-background: #027FAF;
+  --interactive-interactive_0-hover-background: #007AB5;
   --interactive-interactive_0-hover-text: #FFFFFF;
   --interactive-interactive_0-active-background: #CDE9E3;
   --interactive-interactive_0-active-text: #000000;

--- a/packages/theme/src/themes/fram-theme/theme.module.css
+++ b/packages/theme/src/themes/fram-theme/theme.module.css
@@ -33,7 +33,7 @@
   --static-background-background_2-text: #000000;
   --static-background-background_3-background: #D5D7D9;
   --static-background-background_3-text: #000000;
-  --static-background-background_accent_0-background: #027FAF;
+  --static-background-background_accent_0-background: #007AB5;
   --static-background-background_accent_0-text: #FFFFFF;
   --static-background-background_accent_1-background: #006594;
   --static-background-background_accent_1-text: #FFFFFF;
@@ -43,7 +43,7 @@
   --static-background-background_accent_3-text: #FFFFFF;
   --static-background-background_accent_4-background: #F0E991;
   --static-background-background_accent_4-text: #000000;
-  --static-background-background_accent_5-background: #027FAF;
+  --static-background-background_accent_5-background: #007AB5;
   --static-background-background_accent_5-text: #FFFFFF;
   --static-transport-transport_city-background: #82B962;
   --static-transport-transport_city-text: #000000;
@@ -78,7 +78,7 @@
 
   --interactive-interactive_0-default-background: #005685;
   --interactive-interactive_0-default-text: #FFFFFF;
-  --interactive-interactive_0-hover-background: #027FAF;
+  --interactive-interactive_0-hover-background: #007AB5;
   --interactive-interactive_0-hover-text: #FFFFFF;
   --interactive-interactive_0-active-background: #CDE9E3;
   --interactive-interactive_0-active-text: #000000;
@@ -172,7 +172,7 @@
   --static-background-background_2-text: #FFFFFF;
   --static-background-background_3-background: #555E65;
   --static-background-background_3-text: #FFFFFF;
-  --static-background-background_accent_0-background: #027FAF;
+  --static-background-background_accent_0-background: #007AB5;
   --static-background-background_accent_0-text: #FFFFFF;
   --static-background-background_accent_1-background: #006594;
   --static-background-background_accent_1-text: #FFFFFF;
@@ -182,7 +182,7 @@
   --static-background-background_accent_3-text: #FFFFFF;
   --static-background-background_accent_4-background: #F0E991;
   --static-background-background_accent_4-text: #000000;
-  --static-background-background_accent_5-background: #027FAF;
+  --static-background-background_accent_5-background: #007AB5;
   --static-background-background_accent_5-text: #FFFFFF;
   --static-transport-transport_city-background: #82B962;
   --static-transport-transport_city-text: #000000;
@@ -217,7 +217,7 @@
 
   --interactive-interactive_0-default-background: #005685;
   --interactive-interactive_0-default-text: #FFFFFF;
-  --interactive-interactive_0-hover-background: #027FAF;
+  --interactive-interactive_0-hover-background: #007AB5;
   --interactive-interactive_0-hover-text: #FFFFFF;
   --interactive-interactive_0-active-background: #CDE9E3;
   --interactive-interactive_0-active-text: #000000;
@@ -311,7 +311,7 @@
   --static-background-background_2-text: #FFFFFF;
   --static-background-background_3-background: #555E65;
   --static-background-background_3-text: #FFFFFF;
-  --static-background-background_accent_0-background: #027FAF;
+  --static-background-background_accent_0-background: #007AB5;
   --static-background-background_accent_0-text: #FFFFFF;
   --static-background-background_accent_1-background: #006594;
   --static-background-background_accent_1-text: #FFFFFF;
@@ -321,7 +321,7 @@
   --static-background-background_accent_3-text: #FFFFFF;
   --static-background-background_accent_4-background: #F0E991;
   --static-background-background_accent_4-text: #000000;
-  --static-background-background_accent_5-background: #027FAF;
+  --static-background-background_accent_5-background: #007AB5;
   --static-background-background_accent_5-text: #FFFFFF;
   --static-transport-transport_city-background: #82B962;
   --static-transport-transport_city-text: #000000;
@@ -356,7 +356,7 @@
 
   --interactive-interactive_0-default-background: #005685;
   --interactive-interactive_0-default-text: #FFFFFF;
-  --interactive-interactive_0-hover-background: #027FAF;
+  --interactive-interactive_0-hover-background: #007AB5;
   --interactive-interactive_0-hover-text: #FFFFFF;
   --interactive-interactive_0-active-background: #CDE9E3;
   --interactive-interactive_0-active-text: #000000;

--- a/packages/theme/src/themes/fram-theme/theme.ts
+++ b/packages/theme/src/themes/fram-theme/theme.ts
@@ -22,7 +22,7 @@ const themes: Themes = {
     interactive: {
       interactive_0: {
         default: contrastColor('#005685', 'light'),
-        hover: contrastColor('#027FAF', 'light'),
+        hover: contrastColor('#007AB5', 'light'),
         active: contrastColor('#CDE9E3', 'dark'),
         disabled: contrastColor('#C7CACC', 'dark'),
         outline: contrastColor('#0D6569', 'light'),
@@ -67,12 +67,12 @@ const themes: Themes = {
         background_1: contrastColor('#F1F2F2', 'dark'),
         background_2: contrastColor('#E3E5E6', 'dark'),
         background_3: contrastColor('#D5D7D9', 'dark'),
-        background_accent_0: contrastColor('#027FAF', 'light'),
+        background_accent_0: contrastColor('#007AB5', 'light'),
         background_accent_1: contrastColor('#006594', 'light'),
         background_accent_2: contrastColor('#CDE9E3', 'dark'),
         background_accent_3: contrastColor('#0D6569', 'light'),
         background_accent_4: contrastColor('#F0E991', 'dark'),
-        background_accent_5: contrastColor('#027FAF', 'light'),
+        background_accent_5: contrastColor('#007AB5', 'light'),
       },
       transport: {
         transport_city: contrastColor('#82B962', 'dark'),
@@ -120,7 +120,7 @@ const themes: Themes = {
     interactive: {
       interactive_0: {
         default: contrastColor('#005685', 'light'),
-        hover: contrastColor('#027FAF', 'light'),
+        hover: contrastColor('#007AB5', 'light'),
         active: contrastColor('#CDE9E3', 'dark'),
         disabled: contrastColor('#C7CACC', 'dark'),
         outline: contrastColor('#0D6569', 'light'),
@@ -165,12 +165,12 @@ const themes: Themes = {
         background_1: contrastColor('#2B343A', 'light'),
         background_2: contrastColor('#37424A', 'light'),
         background_3: contrastColor('#555E65', 'light'),
-        background_accent_0: contrastColor('#027FAF', 'light'),
+        background_accent_0: contrastColor('#007AB5', 'light'),
         background_accent_1: contrastColor('#006594', 'light'),
         background_accent_2: contrastColor('#CDE9E3', 'dark'),
         background_accent_3: contrastColor('#0D6569', 'light'),
         background_accent_4: contrastColor('#F0E991', 'dark'),
-        background_accent_5: contrastColor('#027FAF', 'light'),
+        background_accent_5: contrastColor('#007AB5', 'light'),
       },
 
       transport: {


### PR DESCRIPTION
FRAM has a new blue primary color that is compliant with [WCAG 2.1 1.4.3](https://www.uutilsynet.no/wcag-standarden/143-kontrast-minimum-niva-aa/95) when used with a white text color. 