### PR TITLE
fix: mixed text color for FRAM in app

### DIFF
--- a/packages/theme/src/themes/fram-theme/theme.css
+++ b/packages/theme/src/themes/fram-theme/theme.css
@@ -256,8 +256,8 @@
   --interactive-interactive_2-default-text: #FFFFFF;
   --interactive-interactive_2-hover-background: #0D6569;
   --interactive-interactive_2-hover-text: #FFFFFF;
-  --interactive-interactive_2-active-background: #679C9F;
-  --interactive-interactive_2-active-text: #000000;
+  --interactive-interactive_2-active-background: #015959;
+  --interactive-interactive_2-active-text: #FFFFFF;
   --interactive-interactive_2-disabled-background: #D6D7DB;
   --interactive-interactive_2-disabled-text: #000000;
   --interactive-interactive_2-outline-background: #CDE9E3;
@@ -426,8 +426,8 @@
   --interactive-interactive_2-default-text: #FFFFFF;
   --interactive-interactive_2-hover-background: #0D6569;
   --interactive-interactive_2-hover-text: #FFFFFF;
-  --interactive-interactive_2-active-background: #679C9F;
-  --interactive-interactive_2-active-text: #000000;
+  --interactive-interactive_2-active-background: #015959;
+  --interactive-interactive_2-active-text: #FFFFFF;
   --interactive-interactive_2-disabled-background: #D6D7DB;
   --interactive-interactive_2-disabled-text: #000000;
   --interactive-interactive_2-outline-background: #CDE9E3;

--- a/packages/theme/src/themes/fram-theme/theme.module.css
+++ b/packages/theme/src/themes/fram-theme/theme.module.css
@@ -256,8 +256,8 @@
   --interactive-interactive_2-default-text: #FFFFFF;
   --interactive-interactive_2-hover-background: #0D6569;
   --interactive-interactive_2-hover-text: #FFFFFF;
-  --interactive-interactive_2-active-background: #679C9F;
-  --interactive-interactive_2-active-text: #000000;
+  --interactive-interactive_2-active-background: #015959;
+  --interactive-interactive_2-active-text: #FFFFFF;
   --interactive-interactive_2-disabled-background: #D6D7DB;
   --interactive-interactive_2-disabled-text: #000000;
   --interactive-interactive_2-outline-background: #CDE9E3;
@@ -426,8 +426,8 @@
   --interactive-interactive_2-default-text: #FFFFFF;
   --interactive-interactive_2-hover-background: #0D6569;
   --interactive-interactive_2-hover-text: #FFFFFF;
-  --interactive-interactive_2-active-background: #679C9F;
-  --interactive-interactive_2-active-text: #000000;
+  --interactive-interactive_2-active-background: #015959;
+  --interactive-interactive_2-active-text: #FFFFFF;
   --interactive-interactive_2-disabled-background: #D6D7DB;
   --interactive-interactive_2-disabled-text: #000000;
   --interactive-interactive_2-outline-background: #CDE9E3;

--- a/packages/theme/src/themes/fram-theme/theme.ts
+++ b/packages/theme/src/themes/fram-theme/theme.ts
@@ -176,7 +176,7 @@ const themes: Themes = {
       interactive_2: {
         default: contrastColor('#012C44', 'light'),
         hover: contrastColor('#0D6569', 'light'),
-        active: contrastColor('#679C9F', 'dark'),
+        active: contrastColor('#015959', 'light'),
         disabled: contrastColor('#D6D7DB', 'dark'),
         outline: contrastColor('#CDE9E3', 'dark'),
         destructive: contrastColor('#EF7684', 'dark'),


### PR DESCRIPTION
Fixes https://github.com/AtB-AS/kundevendt/issues/4098 by using a darker color for interactive_2-active so that the text is white. 
![image](https://github.com/AtB-AS/design-system/assets/43166974/190dd8f1-01a7-49e9-a9eb-f7fa8c2054b7)
