### PR TITLE
fix: Add height and width to TravelPlanning

### DIFF
--- a/packages/assets/files/fram/colors/images/dark/TravelPlanning.svg
+++ b/packages/assets/files/fram/colors/images/dark/TravelPlanning.svg
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!-- Generator: Adobe Illustrator 26.4.1, SVG Export Plug-In . SVG Version: 6.00 Build 0)  -->
 <svg version="1.1" id="Layer_1" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" x="0px" y="0px"
-	viewBox="0 0 2400 2000" style="enable-background:new 0 0 2400 2000;">
+	height="320" width="267" viewBox="0 0 2400 2000" style="enable-background:new 0 0 2400 2000;">
 	<g>
 		<g>
 			<path fill="#FFFFFF" d="M1792.4,810.7c-1.4,0-2.8-0.2-4.1-0.7c-4.1-1.4-7.3-4.7-8.4-8.9l-2.7-10.2c-0.4-1.6-1.7-2.9-3.3-3.3

--- a/packages/assets/files/fram/colors/images/light/TravelPlanning.svg
+++ b/packages/assets/files/fram/colors/images/light/TravelPlanning.svg
@@ -2,7 +2,7 @@
 <!-- Generator: Adobe Illustrator 26.4.1, SVG Export Plug-In . SVG Version: 6.00 Build 0)  -->
 <svg version="1.1" id="Layer_1" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" x="0px"
      y="0px"
-     viewBox="0 0 2400 2000" style="enable-background:new 0 0 2400 2000;">
+     height="320" width="267" viewBox="0 0 2400 2000" style="enable-background:new 0 0 2400 2000;">
     <g>
         <g>
             <path fill="#FFFFFF" d="M1792.4,810.7c-1.4,0-2.8-0.2-4.1-0.7c-4.1-1.4-7.3-4.7-8.4-8.9l-2.7-10.2c-0.4-1.6-1.7-2.9-3.3-3.3


### PR DESCRIPTION
Set height and width to fix scaling issues that hid the button on the flexibility info screen.

Fixes https://github.com/AtB-AS/kundevendt/issues/4216 after the assets are regenerated in the app.
