### PR TITLE
feat: add body__primary--strike and body__tertiary--uppercase text styles

### DIFF
--- a/packages/theme/src/typography.css
+++ b/packages/theme/src/typography.css
@@ -16,6 +16,12 @@
   --baseTypo-body__primary--bold-letterSpacing: 0.03125rem;
   --baseTypo-body__primary--bold-fontWeight: 500;
 
+  /* Definitions for body__primary--strike */
+  --baseTypo-body__primary--strike-fontSize: 1rem;
+  --baseTypo-body__primary--strike-lineHeight: 1.25rem;
+  --baseTypo-body__primary--strike-letterSpacing: 0.03125rem;
+  --baseTypo-body__primary--strike-textDecorationLine: line-through;
+
   /* Definitions for body__primary--underline */
   --baseTypo-body__primary--underline-fontSize: 1rem;
   --baseTypo-body__primary--underline-lineHeight: 1.25rem;
@@ -65,6 +71,12 @@
   --baseTypo-body__tertiary--strike-lineHeight: 1rem;
   --baseTypo-body__tertiary--strike-letterSpacing: 0.025rem;
   --baseTypo-body__tertiary--strike-textDecorationLine: line-through;
+
+  /* Definitions for body__tertiary--uppercase */
+  --baseTypo-body__tertiary--uppercase-fontSize: 1rem;
+  --baseTypo-body__tertiary--uppercase-lineHeight: 1.25rem;
+  --baseTypo-body__tertiary--uppercase-letterSpacing: 0.03125rem;
+  --baseTypo-body__tertiary--uppercase-textTransform: uppercase;
 
   /* Definitions for heading__title */
   --baseTypo-heading__title-fontSize: 1rem;
@@ -131,6 +143,12 @@ html {
   letter-spacing: var(--baseTypo-body__primary--bold-letterSpacing, 0.03125rem);
   font-weight: var(--baseTypo-body__primary--bold-fontWeight, 500);
 }
+.typo-body__primary--strike {
+  font-size: var(--baseTypo-body__primary--strike-fontSize, 1rem);
+  line-height: var(--baseTypo-body__primary--strike-lineHeight, 1.25rem);
+  letter-spacing: var(--baseTypo-body__primary--strike-letterSpacing, 0.03125rem);
+  text-decoration: var(--baseTypo-body__primary--strike-textDecorationLine, line-through);
+}
 .typo-body__primary--underline {
   font-size: var(--baseTypo-body__primary--underline-fontSize, 1rem);
   line-height: var(--baseTypo-body__primary--underline-lineHeight, 1.25rem);
@@ -180,6 +198,12 @@ html {
   line-height: var(--baseTypo-body__tertiary--strike-lineHeight, 1rem);
   letter-spacing: var(--baseTypo-body__tertiary--strike-letterSpacing, 0.025rem);
   text-decoration: var(--baseTypo-body__tertiary--strike-textDecorationLine, line-through);
+}
+.typo-body__tertiary--uppercase {
+  font-size: var(--baseTypo-body__tertiary--uppercase-fontSize, 1rem);
+  line-height: var(--baseTypo-body__tertiary--uppercase-lineHeight, 1.25rem);
+  letter-spacing: var(--baseTypo-body__tertiary--uppercase-letterSpacing, 0.03125rem);
+  text-transform: var(--baseTypo-body__tertiary--uppercase-textTransform, uppercase);
 }
 .typo-heading__title {
   font-size: var(--baseTypo-heading__title-fontSize, 1rem);

--- a/packages/theme/src/typography.module.css
+++ b/packages/theme/src/typography.module.css
@@ -16,6 +16,12 @@
   --baseTypo-body__primary--bold-letterSpacing: 0.03125rem;
   --baseTypo-body__primary--bold-fontWeight: 500;
 
+  /* Definitions for body__primary--strike */
+  --baseTypo-body__primary--strike-fontSize: 1rem;
+  --baseTypo-body__primary--strike-lineHeight: 1.25rem;
+  --baseTypo-body__primary--strike-letterSpacing: 0.03125rem;
+  --baseTypo-body__primary--strike-textDecorationLine: line-through;
+
   /* Definitions for body__primary--underline */
   --baseTypo-body__primary--underline-fontSize: 1rem;
   --baseTypo-body__primary--underline-lineHeight: 1.25rem;
@@ -65,6 +71,12 @@
   --baseTypo-body__tertiary--strike-lineHeight: 1rem;
   --baseTypo-body__tertiary--strike-letterSpacing: 0.025rem;
   --baseTypo-body__tertiary--strike-textDecorationLine: line-through;
+
+  /* Definitions for body__tertiary--uppercase */
+  --baseTypo-body__tertiary--uppercase-fontSize: 1rem;
+  --baseTypo-body__tertiary--uppercase-lineHeight: 1.25rem;
+  --baseTypo-body__tertiary--uppercase-letterSpacing: 0.03125rem;
+  --baseTypo-body__tertiary--uppercase-textTransform: uppercase;
 
   /* Definitions for heading__title */
   --baseTypo-heading__title-fontSize: 1rem;
@@ -131,6 +143,12 @@
   letter-spacing: var(--baseTypo-body__primary--bold-letterSpacing, 0.03125rem);
   font-weight: var(--baseTypo-body__primary--bold-fontWeight, 500);
 }
+.typo-body__primary--strike {
+  font-size: var(--baseTypo-body__primary--strike-fontSize, 1rem);
+  line-height: var(--baseTypo-body__primary--strike-lineHeight, 1.25rem);
+  letter-spacing: var(--baseTypo-body__primary--strike-letterSpacing, 0.03125rem);
+  text-decoration: var(--baseTypo-body__primary--strike-textDecorationLine, line-through);
+}
 .typo-body__primary--underline {
   font-size: var(--baseTypo-body__primary--underline-fontSize, 1rem);
   line-height: var(--baseTypo-body__primary--underline-lineHeight, 1.25rem);
@@ -180,6 +198,12 @@
   line-height: var(--baseTypo-body__tertiary--strike-lineHeight, 1rem);
   letter-spacing: var(--baseTypo-body__tertiary--strike-letterSpacing, 0.025rem);
   text-decoration: var(--baseTypo-body__tertiary--strike-textDecorationLine, line-through);
+}
+.typo-body__tertiary--uppercase {
+  font-size: var(--baseTypo-body__tertiary--uppercase-fontSize, 1rem);
+  line-height: var(--baseTypo-body__tertiary--uppercase-lineHeight, 1.25rem);
+  letter-spacing: var(--baseTypo-body__tertiary--uppercase-letterSpacing, 0.03125rem);
+  text-transform: var(--baseTypo-body__tertiary--uppercase-textTransform, uppercase);
 }
 .typo-heading__title {
   font-size: var(--baseTypo-heading__title-fontSize, 1rem);

--- a/packages/theme/src/typography/android.ts
+++ b/packages/theme/src/typography/android.ts
@@ -35,6 +35,10 @@ export const androidTextTypeStyles: TextTypeStyles = {
     ...primaryBase,
     fontWeight: '500',
   },
+  'body__primary--strike': {
+    ...primaryBase,
+    textDecorationLine: 'line-through'
+  },
   'body__primary--underline': {
     ...primaryBase,
     textDecorationLine: 'underline',

--- a/packages/theme/src/typography/android.ts
+++ b/packages/theme/src/typography/android.ts
@@ -75,6 +75,10 @@ export const androidTextTypeStyles: TextTypeStyles = {
     ...tertiaryBase,
     textDecorationLine: 'line-through',
   },
+  'body__tertiary--uppercase': {
+    ...primaryBase,
+    textTransform: 'uppercase'
+  },
   heading__title: {
     ...primaryBase,
     fontWeight: 'bold',

--- a/packages/theme/src/typography/ios.ts
+++ b/packages/theme/src/typography/ios.ts
@@ -73,6 +73,10 @@ export const iosTextTypeStyles: TextTypeStyles = {
     ...tertiaryBase,
     textDecorationLine: 'line-through',
   },
+  'body__tertiary--uppercase': {
+    ...primaryBase,
+    textTransform: 'uppercase'
+  },
   heading__title: {
     ...primaryBase,
     fontWeight: 'bold',

--- a/packages/theme/src/typography/ios.ts
+++ b/packages/theme/src/typography/ios.ts
@@ -33,6 +33,10 @@ export const iosTextTypeStyles: TextTypeStyles = {
     ...primaryBase,
     fontWeight: '600',
   },
+  'body__primary--strike': {
+    ...primaryBase,
+    textDecorationLine: 'line-through'
+  },
   'body__primary--underline': {
     ...primaryBase,
     textDecorationLine: 'underline',

--- a/packages/theme/src/typography/types.ts
+++ b/packages/theme/src/typography/types.ts
@@ -1,5 +1,6 @@
 export const textNames = [
   'body__primary',
+  'body__primary--strike',
   'body__primary--bold',
   'body__primary--underline',
   'body__primary--big',

--- a/packages/theme/src/typography/types.ts
+++ b/packages/theme/src/typography/types.ts
@@ -10,6 +10,7 @@ export const textNames = [
   'body__secondary',
   'body__secondary--bold',
   'body__tertiary',
+  'body__tertiary--uppercase',
   'body__tertiary--strike',
   'heading__title',
   'heading__component',


### PR DESCRIPTION
### Added missing styles from [Figma](https://www.figma.com/file/3rlcixpbhfBglNSctUkMys/Text%2C-colors%2C-sizes-and-effects?type=design&node-id=2017-4749&mode=design&t=tExTA63d432gEGF4-4).

[`body__primary--strike`](https://www.figma.com/file/3rlcixpbhfBglNSctUkMys/Text%2C-colors%2C-sizes-and-effects?type=design&node-id=2250-4671&mode=design&t=tExTA63d432gEGF4-4)  was needed for https://github.com/AtB-AS/kundevendt/issues/15925, and [`body__tertiary--uppercase`](https://www.figma.com/file/3rlcixpbhfBglNSctUkMys/Text%2C-colors%2C-sizes-and-effects?type=design&node-id=2256-4823&mode=design&t=tExTA63d432gEGF4-4) was also missing. 



