### PR TITLE
feat!: add xSmall icon size and make small larger

### DIFF
--- a/packages/theme/src/sizes.ts
+++ b/packages/theme/src/sizes.ts
@@ -9,7 +9,8 @@ export const spacings = {
 export const iconSizes = {
   large: 28,
   normal: 20,
-  small: 10,
+  small: 16,
+  xSmall: 12,
 };
 
 export const borderRadius = {

--- a/packages/theme/src/themes/atb-theme/theme.css
+++ b/packages/theme/src/themes/atb-theme/theme.css
@@ -19,7 +19,8 @@
 
   --icon-size-large: 1.75rem;
   --icon-size-normal: 1.25rem;
-  --icon-size-small: 0.625rem;
+  --icon-size-small: 1rem;
+  --icon-size-xSmall: 0.75rem;
 
   --text-colors-primary: #000000;
   --text-colors-secondary: #555E65;
@@ -189,7 +190,8 @@
 
   --icon-size-large: 1.75rem;
   --icon-size-normal: 1.25rem;
-  --icon-size-small: 0.625rem;
+  --icon-size-small: 1rem;
+  --icon-size-xSmall: 0.75rem;
 
   --text-colors-primary: #FFFFFF;
   --text-colors-secondary: #E3E5E6;
@@ -359,7 +361,8 @@
 
   --icon-size-large: 1.75rem;
   --icon-size-normal: 1.25rem;
-  --icon-size-small: 0.625rem;
+  --icon-size-small: 1rem;
+  --icon-size-xSmall: 0.75rem;
 
   --text-colors-primary: #FFFFFF;
   --text-colors-secondary: #E3E5E6;

--- a/packages/theme/src/themes/atb-theme/theme.module.css
+++ b/packages/theme/src/themes/atb-theme/theme.module.css
@@ -19,7 +19,8 @@
 
   --icon-size-large: 1.75rem;
   --icon-size-normal: 1.25rem;
-  --icon-size-small: 0.625rem;
+  --icon-size-small: 1rem;
+  --icon-size-xSmall: 0.75rem;
 
   --text-colors-primary: #000000;
   --text-colors-secondary: #555E65;
@@ -189,7 +190,8 @@
 
   --icon-size-large: 1.75rem;
   --icon-size-normal: 1.25rem;
-  --icon-size-small: 0.625rem;
+  --icon-size-small: 1rem;
+  --icon-size-xSmall: 0.75rem;
 
   --text-colors-primary: #FFFFFF;
   --text-colors-secondary: #E3E5E6;
@@ -359,7 +361,8 @@
 
   --icon-size-large: 1.75rem;
   --icon-size-normal: 1.25rem;
-  --icon-size-small: 0.625rem;
+  --icon-size-small: 1rem;
+  --icon-size-xSmall: 0.75rem;
 
   --text-colors-primary: #FFFFFF;
   --text-colors-secondary: #E3E5E6;

--- a/packages/theme/src/themes/fram-theme/theme.css
+++ b/packages/theme/src/themes/fram-theme/theme.css
@@ -19,7 +19,8 @@
 
   --icon-size-large: 1.75rem;
   --icon-size-normal: 1.25rem;
-  --icon-size-small: 0.625rem;
+  --icon-size-small: 1rem;
+  --icon-size-xSmall: 0.75rem;
 
   --text-colors-primary: #000000;
   --text-colors-secondary: #555E65;
@@ -189,7 +190,8 @@
 
   --icon-size-large: 1.75rem;
   --icon-size-normal: 1.25rem;
-  --icon-size-small: 0.625rem;
+  --icon-size-small: 1rem;
+  --icon-size-xSmall: 0.75rem;
 
   --text-colors-primary: #FFFFFF;
   --text-colors-secondary: #F1F2F2;
@@ -359,7 +361,8 @@
 
   --icon-size-large: 1.75rem;
   --icon-size-normal: 1.25rem;
-  --icon-size-small: 0.625rem;
+  --icon-size-small: 1rem;
+  --icon-size-xSmall: 0.75rem;
 
   --text-colors-primary: #FFFFFF;
   --text-colors-secondary: #F1F2F2;

--- a/packages/theme/src/themes/fram-theme/theme.module.css
+++ b/packages/theme/src/themes/fram-theme/theme.module.css
@@ -19,7 +19,8 @@
 
   --icon-size-large: 1.75rem;
   --icon-size-normal: 1.25rem;
-  --icon-size-small: 0.625rem;
+  --icon-size-small: 1rem;
+  --icon-size-xSmall: 0.75rem;
 
   --text-colors-primary: #000000;
   --text-colors-secondary: #555E65;
@@ -189,7 +190,8 @@
 
   --icon-size-large: 1.75rem;
   --icon-size-normal: 1.25rem;
-  --icon-size-small: 0.625rem;
+  --icon-size-small: 1rem;
+  --icon-size-xSmall: 0.75rem;
 
   --text-colors-primary: #FFFFFF;
   --text-colors-secondary: #F1F2F2;
@@ -359,7 +361,8 @@
 
   --icon-size-large: 1.75rem;
   --icon-size-normal: 1.25rem;
-  --icon-size-small: 0.625rem;
+  --icon-size-small: 1rem;
+  --icon-size-xSmall: 0.75rem;
 
   --text-colors-primary: #FFFFFF;
   --text-colors-secondary: #F1F2F2;

--- a/packages/theme/src/themes/nfk-theme/theme.css
+++ b/packages/theme/src/themes/nfk-theme/theme.css
@@ -19,7 +19,8 @@
 
   --icon-size-large: 1.75rem;
   --icon-size-normal: 1.25rem;
-  --icon-size-small: 0.625rem;
+  --icon-size-small: 1rem;
+  --icon-size-xSmall: 0.75rem;
 
   --text-colors-primary: #003441;
   --text-colors-secondary: rgba(0, 52, 65, 0.7);
@@ -189,7 +190,8 @@
 
   --icon-size-large: 1.75rem;
   --icon-size-normal: 1.25rem;
-  --icon-size-small: 0.625rem;
+  --icon-size-small: 1rem;
+  --icon-size-xSmall: 0.75rem;
 
   --text-colors-primary: #FFFFFF;
   --text-colors-secondary: rgba(255, 255, 255, 0.6);
@@ -359,7 +361,8 @@
 
   --icon-size-large: 1.75rem;
   --icon-size-normal: 1.25rem;
-  --icon-size-small: 0.625rem;
+  --icon-size-small: 1rem;
+  --icon-size-xSmall: 0.75rem;
 
   --text-colors-primary: #FFFFFF;
   --text-colors-secondary: rgba(255, 255, 255, 0.6);

--- a/packages/theme/src/themes/nfk-theme/theme.module.css
+++ b/packages/theme/src/themes/nfk-theme/theme.module.css
@@ -19,7 +19,8 @@
 
   --icon-size-large: 1.75rem;
   --icon-size-normal: 1.25rem;
-  --icon-size-small: 0.625rem;
+  --icon-size-small: 1rem;
+  --icon-size-xSmall: 0.75rem;
 
   --text-colors-primary: #003441;
   --text-colors-secondary: rgba(0, 52, 65, 0.7);
@@ -189,7 +190,8 @@
 
   --icon-size-large: 1.75rem;
   --icon-size-normal: 1.25rem;
-  --icon-size-small: 0.625rem;
+  --icon-size-small: 1rem;
+  --icon-size-xSmall: 0.75rem;
 
   --text-colors-primary: #FFFFFF;
   --text-colors-secondary: rgba(255, 255, 255, 0.6);
@@ -359,7 +361,8 @@
 
   --icon-size-large: 1.75rem;
   --icon-size-normal: 1.25rem;
-  --icon-size-small: 0.625rem;
+  --icon-size-small: 1rem;
+  --icon-size-xSmall: 0.75rem;
 
   --text-colors-primary: #FFFFFF;
   --text-colors-secondary: rgba(255, 255, 255, 0.6);


### PR DESCRIPTION
**Breaking change**: 

- Changes small icon size to 16
- Adds a new icon size, xSmall = 12

closes https://github.com/AtB-AS/kundevendt/issues/3834

## Next steps

### App

1. Replace all occurrences of "small" icons with "xSmall" 
	- https://github.com/AtB-AS/mittatb-app/pull/4274
3. Track down icons that are out of sync with Figma, and update them

### Planner web 

There's a couple of occurrences of "small" icons, that probably can be replaced with "xSmall"

- https://github.com/AtB-AS/planner-web/pull/215

### Webshop

I found no occurrences of small icons 🤯 So no change should be needed.
