### PR TITLE
fix: issue with generating types on windows

### DIFF
--- a/packages/assets/package.json
+++ b/packages/assets/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@atb-as/generate-assets",
-  "version": "10.1.0",
+  "version": "10.1.1-alpha.0",
   "private": false,
   "description": "OOS Design System generate-assets",
   "license": "EUPL-1.2",

--- a/packages/assets/src/generateTs.ts
+++ b/packages/assets/src/generateTs.ts
@@ -1,6 +1,6 @@
 import fs from 'fs/promises';
 import path from 'path';
-import {AssetType} from './utils';
+import {AssetType, normalizeToUnix} from './utils';
 
 type Data = Partial<{
   mono: Record<string, MonoType>;
@@ -121,7 +121,8 @@ function toTypeCoonstruct(
         : 'mono'
       : assetTypeInput;
 
-  if (assetType === 'mono' && relative.match(/(\/dark\/|\/light\/)/)) {
+  // If is mono and has dark/light in the path, skip the asset.
+  if (assetType === 'mono' && relative.match(/(dark|light)/)) {
     return undefined;
   }
 
@@ -146,7 +147,7 @@ function toTypeCoonstruct(
 const darkOrLight = /\/(?:dark|light)\//;
 
 function toIDPath(relative: string) {
-  return relative
+  return normalizeToUnix(relative)
     .replace(darkOrLight, '/')
     .replace(
       /^\/?(?:(?:mono|colors)\/)?(?:(?:illustrations|images|icons)\/)?(.*)\..{3}$/,
@@ -157,9 +158,9 @@ function isDarkable(relative: string) {
   return relative.match(darkOrLight) !== null;
 }
 function getColorType(relative: string): ColorType['colorType'] {
-  const colorType = relative.match(
-    /^\/?(?:(?:mono|colors)\/)?(illustrations|images|icons)\//,
-  )?.[1];
+  const colorType = normalizeToUnix(relative)
+    // Extract the color type
+    .match(/^\/?(?:(?:mono|colors)\/)?(illustrations|images|icons)\//)?.[1];
 
   switch (colorType) {
     case 'illustrations':


### PR DESCRIPTION
File IDs generated in typescript types will not work as expected on Windows as paths aren't normalized when used as ID. This will cause generated-assets to generate wrong TypeScript definitions and icons will not match full paths.

This normalizes ot Unix pathing for IDs, making it consistent with existing use.