### PR TITLE
fix: glob for copying CSS files works on Windows

### DIFF
--- a/packages/theme/package.json
+++ b/packages/theme/package.json
@@ -15,7 +15,7 @@
     "clean": "rm -rf lib",
     "test": "echo \"Error: run tests from root\" && exit 1",
     "build": "yarn create-css && yarn copy-css && tsc -p tsconfig.build.json",
-    "copy-css": "copyfiles -u 1 'src/**/*.{css,woff,woff2,ttf,eot,svg,png}' lib/",
+    "copy-css": "copyfiles -u 1 \"src/**/*.{css,woff,woff2,ttf,eot,svg,png}\" lib/",
     "create-css": "ts-node ./tools/create-css.ts"
   },
   "devDependencies": {


### PR DESCRIPTION
CSS files were not copied to the `/lib` folder when running the build script. In accordance with the [copyfiles docs](https://www.npmjs.com/package/copyfiles), this solves the issue on Windows and should still work on Mac, **but this should be tested by a Mac used before merging**

**How to test**
1. Check out this branch on a Mac
3. run `cd packages/theme`
4. Make sure the `./lib` folder does not exist
5. run `yarn build`
6. The `./lib` folder should exist and should contain `typography.css` and `typography.module.css` in the root.