### PR TITLE
feat: update status color

### DIFF
--- a/packages/theme/src/theme.ts
+++ b/packages/theme/src/theme.ts
@@ -27,6 +27,11 @@ export type TransportColor = {
   secondary: ContrastColor;
 };
 
+export type StatusColor = {
+  primary: ContrastColor;
+  secondary: ContrastColor;
+};
+
 export type InteractiveColor = {
   default: ContrastColor;
   hover: ContrastColor;
@@ -76,10 +81,10 @@ export interface Theme {
     };
 
     status: {
-      valid: ContrastColor;
-      info: ContrastColor;
-      warning: ContrastColor;
-      error: ContrastColor;
+      valid: StatusColor;
+      info: StatusColor;
+      warning: StatusColor;
+      error: StatusColor;
     };
 
     zone_selection: {

--- a/packages/theme/src/themes/atb-theme/theme.css
+++ b/packages/theme/src/themes/atb-theme/theme.css
@@ -46,14 +46,22 @@
   --static-background-background_accent_4-text: #000000;
   --static-background-background_accent_5-background: #A6D1D9;
   --static-background-background_accent_5-text: #000000;
-  --static-status-valid-background: #A2AD00;
-  --static-status-valid-text: #000000;
-  --static-status-info-background: #71D6E0;
-  --static-status-info-text: #000000;
-  --static-status-warning-background: #E4D700;
-  --static-status-warning-text: #000000;
-  --static-status-error-background: #A51140;
-  --static-status-error-text: #FFFFFF;
+  --static-status-valid-primary-background: #909A00;
+  --static-status-valid-primary-text: #000000;
+  --static-status-valid-secondary-background: #E5E8B8;
+  --static-status-valid-secondary-text: #000000;
+  --static-status-info-primary-background: #007C92;
+  --static-status-info-primary-text: #FFFFFF;
+  --static-status-info-secondary-background: #DEF5F8;
+  --static-status-info-secondary-text: #000000;
+  --static-status-warning-primary-background: #E4D700;
+  --static-status-warning-primary-text: #000000;
+  --static-status-warning-secondary-background: #FBF9DA;
+  --static-status-warning-secondary-text: #000000;
+  --static-status-error-primary-background: #B74166;
+  --static-status-error-primary-text: #000000;
+  --static-status-error-secondary-background: #F4E1E7;
+  --static-status-error-secondary-text: #000000;
   --static-zone_selection-from-background: #A2AD00;
   --static-zone_selection-from-text: #000000;
   --static-zone_selection-to-background: #71D6E0;
@@ -217,14 +225,22 @@
   --static-background-background_accent_4-text: #000000;
   --static-background-background_accent_5-background: #2B343A;
   --static-background-background_accent_5-text: #FFFFFF;
-  --static-status-valid-background: #A2AD00;
-  --static-status-valid-text: #000000;
-  --static-status-info-background: #71D6E0;
-  --static-status-info-text: #000000;
-  --static-status-warning-background: #E4D700;
-  --static-status-warning-text: #000000;
-  --static-status-error-background: #A51140;
-  --static-status-error-text: #FFFFFF;
+  --static-status-valid-primary-background: #909A00;
+  --static-status-valid-primary-text: #000000;
+  --static-status-valid-secondary-background: #464A00;
+  --static-status-valid-secondary-text: #FFFFFF;
+  --static-status-info-primary-background: #007C92;
+  --static-status-info-primary-text: #FFFFFF;
+  --static-status-info-secondary-background: #003943;
+  --static-status-info-secondary-text: #FFFFFF;
+  --static-status-warning-primary-background: #E4D700;
+  --static-status-warning-primary-text: #000000;
+  --static-status-warning-secondary-background: #1F2100;
+  --static-status-warning-secondary-text: #FFFFFF;
+  --static-status-error-primary-background: #B74166;
+  --static-status-error-primary-text: #000000;
+  --static-status-error-secondary-background: #380616;
+  --static-status-error-secondary-text: #FFFFFF;
   --static-zone_selection-from-background: #A2AD00;
   --static-zone_selection-from-text: #000000;
   --static-zone_selection-to-background: #71D6E0;
@@ -388,14 +404,22 @@
   --static-background-background_accent_4-text: #000000;
   --static-background-background_accent_5-background: #2B343A;
   --static-background-background_accent_5-text: #FFFFFF;
-  --static-status-valid-background: #A2AD00;
-  --static-status-valid-text: #000000;
-  --static-status-info-background: #71D6E0;
-  --static-status-info-text: #000000;
-  --static-status-warning-background: #E4D700;
-  --static-status-warning-text: #000000;
-  --static-status-error-background: #A51140;
-  --static-status-error-text: #FFFFFF;
+  --static-status-valid-primary-background: #909A00;
+  --static-status-valid-primary-text: #000000;
+  --static-status-valid-secondary-background: #464A00;
+  --static-status-valid-secondary-text: #FFFFFF;
+  --static-status-info-primary-background: #007C92;
+  --static-status-info-primary-text: #FFFFFF;
+  --static-status-info-secondary-background: #003943;
+  --static-status-info-secondary-text: #FFFFFF;
+  --static-status-warning-primary-background: #E4D700;
+  --static-status-warning-primary-text: #000000;
+  --static-status-warning-secondary-background: #1F2100;
+  --static-status-warning-secondary-text: #FFFFFF;
+  --static-status-error-primary-background: #B74166;
+  --static-status-error-primary-text: #000000;
+  --static-status-error-secondary-background: #380616;
+  --static-status-error-secondary-text: #FFFFFF;
   --static-zone_selection-from-background: #A2AD00;
   --static-zone_selection-from-text: #000000;
   --static-zone_selection-to-background: #71D6E0;
@@ -555,21 +579,37 @@
   background-color: var(--static-background-background_accent_5-background);
   color: var(--static-background-background_accent_5-text);
 }
-.static-status-valid {
-  background-color: var(--static-status-valid-background);
-  color: var(--static-status-valid-text);
+.static-valid-primary {
+  background-color: var(--static-valid-primary-background);
+  color: var(--static-valid-primary-text);
 }
-.static-status-info {
-  background-color: var(--static-status-info-background);
-  color: var(--static-status-info-text);
+.static-valid-secondary {
+  background-color: var(--static-valid-secondary-background);
+  color: var(--static-valid-secondary-text);
 }
-.static-status-warning {
-  background-color: var(--static-status-warning-background);
-  color: var(--static-status-warning-text);
+.static-info-primary {
+  background-color: var(--static-info-primary-background);
+  color: var(--static-info-primary-text);
 }
-.static-status-error {
-  background-color: var(--static-status-error-background);
-  color: var(--static-status-error-text);
+.static-info-secondary {
+  background-color: var(--static-info-secondary-background);
+  color: var(--static-info-secondary-text);
+}
+.static-warning-primary {
+  background-color: var(--static-warning-primary-background);
+  color: var(--static-warning-primary-text);
+}
+.static-warning-secondary {
+  background-color: var(--static-warning-secondary-background);
+  color: var(--static-warning-secondary-text);
+}
+.static-error-primary {
+  background-color: var(--static-error-primary-background);
+  color: var(--static-error-primary-text);
+}
+.static-error-secondary {
+  background-color: var(--static-error-secondary-background);
+  color: var(--static-error-secondary-text);
 }
 .static-zone_selection-from {
   background-color: var(--static-zone_selection-from-background);

--- a/packages/theme/src/themes/atb-theme/theme.module.css
+++ b/packages/theme/src/themes/atb-theme/theme.module.css
@@ -46,14 +46,22 @@
   --static-background-background_accent_4-text: #000000;
   --static-background-background_accent_5-background: #A6D1D9;
   --static-background-background_accent_5-text: #000000;
-  --static-status-valid-background: #A2AD00;
-  --static-status-valid-text: #000000;
-  --static-status-info-background: #71D6E0;
-  --static-status-info-text: #000000;
-  --static-status-warning-background: #E4D700;
-  --static-status-warning-text: #000000;
-  --static-status-error-background: #A51140;
-  --static-status-error-text: #FFFFFF;
+  --static-status-valid-primary-background: #909A00;
+  --static-status-valid-primary-text: #000000;
+  --static-status-valid-secondary-background: #E5E8B8;
+  --static-status-valid-secondary-text: #000000;
+  --static-status-info-primary-background: #007C92;
+  --static-status-info-primary-text: #FFFFFF;
+  --static-status-info-secondary-background: #DEF5F8;
+  --static-status-info-secondary-text: #000000;
+  --static-status-warning-primary-background: #E4D700;
+  --static-status-warning-primary-text: #000000;
+  --static-status-warning-secondary-background: #FBF9DA;
+  --static-status-warning-secondary-text: #000000;
+  --static-status-error-primary-background: #B74166;
+  --static-status-error-primary-text: #000000;
+  --static-status-error-secondary-background: #F4E1E7;
+  --static-status-error-secondary-text: #000000;
   --static-zone_selection-from-background: #A2AD00;
   --static-zone_selection-from-text: #000000;
   --static-zone_selection-to-background: #71D6E0;
@@ -217,14 +225,22 @@
   --static-background-background_accent_4-text: #000000;
   --static-background-background_accent_5-background: #2B343A;
   --static-background-background_accent_5-text: #FFFFFF;
-  --static-status-valid-background: #A2AD00;
-  --static-status-valid-text: #000000;
-  --static-status-info-background: #71D6E0;
-  --static-status-info-text: #000000;
-  --static-status-warning-background: #E4D700;
-  --static-status-warning-text: #000000;
-  --static-status-error-background: #A51140;
-  --static-status-error-text: #FFFFFF;
+  --static-status-valid-primary-background: #909A00;
+  --static-status-valid-primary-text: #000000;
+  --static-status-valid-secondary-background: #464A00;
+  --static-status-valid-secondary-text: #FFFFFF;
+  --static-status-info-primary-background: #007C92;
+  --static-status-info-primary-text: #FFFFFF;
+  --static-status-info-secondary-background: #003943;
+  --static-status-info-secondary-text: #FFFFFF;
+  --static-status-warning-primary-background: #E4D700;
+  --static-status-warning-primary-text: #000000;
+  --static-status-warning-secondary-background: #1F2100;
+  --static-status-warning-secondary-text: #FFFFFF;
+  --static-status-error-primary-background: #B74166;
+  --static-status-error-primary-text: #000000;
+  --static-status-error-secondary-background: #380616;
+  --static-status-error-secondary-text: #FFFFFF;
   --static-zone_selection-from-background: #A2AD00;
   --static-zone_selection-from-text: #000000;
   --static-zone_selection-to-background: #71D6E0;
@@ -388,14 +404,22 @@
   --static-background-background_accent_4-text: #000000;
   --static-background-background_accent_5-background: #2B343A;
   --static-background-background_accent_5-text: #FFFFFF;
-  --static-status-valid-background: #A2AD00;
-  --static-status-valid-text: #000000;
-  --static-status-info-background: #71D6E0;
-  --static-status-info-text: #000000;
-  --static-status-warning-background: #E4D700;
-  --static-status-warning-text: #000000;
-  --static-status-error-background: #A51140;
-  --static-status-error-text: #FFFFFF;
+  --static-status-valid-primary-background: #909A00;
+  --static-status-valid-primary-text: #000000;
+  --static-status-valid-secondary-background: #464A00;
+  --static-status-valid-secondary-text: #FFFFFF;
+  --static-status-info-primary-background: #007C92;
+  --static-status-info-primary-text: #FFFFFF;
+  --static-status-info-secondary-background: #003943;
+  --static-status-info-secondary-text: #FFFFFF;
+  --static-status-warning-primary-background: #E4D700;
+  --static-status-warning-primary-text: #000000;
+  --static-status-warning-secondary-background: #1F2100;
+  --static-status-warning-secondary-text: #FFFFFF;
+  --static-status-error-primary-background: #B74166;
+  --static-status-error-primary-text: #000000;
+  --static-status-error-secondary-background: #380616;
+  --static-status-error-secondary-text: #FFFFFF;
   --static-zone_selection-from-background: #A2AD00;
   --static-zone_selection-from-text: #000000;
   --static-zone_selection-to-background: #71D6E0;
@@ -555,21 +579,37 @@
   background-color: var(--static-background-background_accent_5-background);
   color: var(--static-background-background_accent_5-text);
 }
-.static-status-valid {
-  background-color: var(--static-status-valid-background);
-  color: var(--static-status-valid-text);
+.static-valid-primary {
+  background-color: var(--static-valid-primary-background);
+  color: var(--static-valid-primary-text);
 }
-.static-status-info {
-  background-color: var(--static-status-info-background);
-  color: var(--static-status-info-text);
+.static-valid-secondary {
+  background-color: var(--static-valid-secondary-background);
+  color: var(--static-valid-secondary-text);
 }
-.static-status-warning {
-  background-color: var(--static-status-warning-background);
-  color: var(--static-status-warning-text);
+.static-info-primary {
+  background-color: var(--static-info-primary-background);
+  color: var(--static-info-primary-text);
 }
-.static-status-error {
-  background-color: var(--static-status-error-background);
-  color: var(--static-status-error-text);
+.static-info-secondary {
+  background-color: var(--static-info-secondary-background);
+  color: var(--static-info-secondary-text);
+}
+.static-warning-primary {
+  background-color: var(--static-warning-primary-background);
+  color: var(--static-warning-primary-text);
+}
+.static-warning-secondary {
+  background-color: var(--static-warning-secondary-background);
+  color: var(--static-warning-secondary-text);
+}
+.static-error-primary {
+  background-color: var(--static-error-primary-background);
+  color: var(--static-error-primary-text);
+}
+.static-error-secondary {
+  background-color: var(--static-error-secondary-background);
+  color: var(--static-error-secondary-text);
 }
 .static-zone_selection-from {
   background-color: var(--static-zone_selection-from-background);

--- a/packages/theme/src/themes/atb-theme/theme.ts
+++ b/packages/theme/src/themes/atb-theme/theme.ts
@@ -48,6 +48,7 @@ export const baseColors = {
   green_900: contrastColor('#1F2100', 'light'),
 
   // blue
+  blue_50: contrastColor('#DEF5F8', 'dark'),
   blue_100: contrastColor('#D4E9EC', 'dark'),
   blue_200: contrastColor('#A6D1D9', 'dark'),
   blue_300: contrastColor('#75B8C4', 'dark'),
@@ -92,6 +93,7 @@ export const baseColors = {
   orange_900: contrastColor('#341805', 'light'),
 
   // yellow
+  yellow_50: contrastColor('#FBF9DA', 'dark'),
   yellow_100: contrastColor('#F0E973', 'dark'),
   yellow_200: contrastColor('#E4D700', 'dark'),
   yellow_300: contrastColor('#C6AE00', 'dark'),
@@ -103,6 +105,7 @@ export const baseColors = {
   yellow_900: contrastColor('#460200', 'light'),
 
   // red
+  red_50: contrastColor('#F4E1E7','dark'),
   red_100: contrastColor('#EED2DB', 'dark'),
   red_200: contrastColor('#E4B8C6', 'dark'),
   red_300: contrastColor('#D691A7', 'dark'),
@@ -247,10 +250,22 @@ const themes: Themes = {
         background_accent_5: baseColors.blue_200,
       },
       status: {
-        valid: baseColors.green_300,
-        info: baseColors.cyan_200,
-        warning: baseColors.yellow_200,
-        error: baseColors.red_600,
+        valid: {
+          primary: baseColors.green_400,
+          secondary: baseColors.green_100,
+        },
+        info: {
+          primary: baseColors.blue_500,
+          secondary: baseColors.blue_50,
+        },
+        warning: {
+          primary: baseColors.yellow_200,
+          secondary: baseColors.yellow_50,
+        },
+        error: {
+          primary: baseColors.red_500,
+          secondary: baseColors.red_50,
+        },
       },
       zone_selection: {
         from: baseColors.green_300,
@@ -386,10 +401,22 @@ const themes: Themes = {
       },
 
       status: {
-        valid: baseColors.green_300,
-        info: baseColors.cyan_200,
-        warning: baseColors.yellow_200,
-        error: baseColors.red_600,
+        valid: {
+          primary: baseColors.green_400,
+          secondary: baseColors.green_700,
+        },
+        info: {
+          primary: baseColors.blue_500,
+          secondary: baseColors.blue_800,
+        },
+        warning: {
+          primary: baseColors.yellow_200,
+          secondary: baseColors.green_900,
+        },
+        error: {
+          primary: baseColors.red_500,
+          secondary: baseColors.red_900,
+        },
       },
       zone_selection: {
         from: baseColors.green_300,

--- a/packages/theme/src/themes/fram-theme/theme.css
+++ b/packages/theme/src/themes/fram-theme/theme.css
@@ -46,14 +46,22 @@
   --static-background-background_accent_4-text: #000000;
   --static-background-background_accent_5-background: #007AB5;
   --static-background-background_accent_5-text: #FFFFFF;
-  --static-status-valid-background: #82B962;
-  --static-status-valid-text: #000000;
-  --static-status-info-background: #8DD4CD;
-  --static-status-info-text: #000000;
-  --static-status-warning-background: #F8DA00;
-  --static-status-warning-text: #000000;
-  --static-status-error-background: #F15629;
-  --static-status-error-text: #FFFFFF;
+  --static-status-valid-primary-background: #82B962;
+  --static-status-valid-primary-text: #000000;
+  --static-status-valid-secondary-background: #82B962;
+  --static-status-valid-secondary-text: #000000;
+  --static-status-info-primary-background: #8DD4CD;
+  --static-status-info-primary-text: #000000;
+  --static-status-info-secondary-background: #8DD4CD;
+  --static-status-info-secondary-text: #000000;
+  --static-status-warning-primary-background: #F8DA00;
+  --static-status-warning-primary-text: #000000;
+  --static-status-warning-secondary-background: #F8DA00;
+  --static-status-warning-secondary-text: #000000;
+  --static-status-error-primary-background: #F15629;
+  --static-status-error-primary-text: #FFFFFF;
+  --static-status-error-secondary-background: #F15629;
+  --static-status-error-secondary-text: #FFFFFF;
   --static-zone_selection-from-background: #82B962;
   --static-zone_selection-from-text: #000000;
   --static-zone_selection-to-background: #005685;
@@ -217,14 +225,22 @@
   --static-background-background_accent_4-text: #000000;
   --static-background-background_accent_5-background: #005685;
   --static-background-background_accent_5-text: #FFFFFF;
-  --static-status-valid-background: #82B962;
-  --static-status-valid-text: #000000;
-  --static-status-info-background: #8DD4CD;
-  --static-status-info-text: #000000;
-  --static-status-warning-background: #F8DA00;
-  --static-status-warning-text: #000000;
-  --static-status-error-background: #F15629;
-  --static-status-error-text: #FFFFFF;
+  --static-status-valid-primary-background: #82B962;
+  --static-status-valid-primary-text: #000000;
+  --static-status-valid-secondary-background: #82B962;
+  --static-status-valid-secondary-text: #000000;
+  --static-status-info-primary-background: #8DD4CD;
+  --static-status-info-primary-text: #000000;
+  --static-status-info-secondary-background: #8DD4CD;
+  --static-status-info-secondary-text: #000000;
+  --static-status-warning-primary-background: #F8DA00;
+  --static-status-warning-primary-text: #000000;
+  --static-status-warning-secondary-background: #F8DA00;
+  --static-status-warning-secondary-text: #000000;
+  --static-status-error-primary-background: #F15629;
+  --static-status-error-primary-text: #FFFFFF;
+  --static-status-error-secondary-background: #F15629;
+  --static-status-error-secondary-text: #FFFFFF;
   --static-zone_selection-from-background: #82B962;
   --static-zone_selection-from-text: #000000;
   --static-zone_selection-to-background: #005685;
@@ -388,14 +404,22 @@
   --static-background-background_accent_4-text: #000000;
   --static-background-background_accent_5-background: #005685;
   --static-background-background_accent_5-text: #FFFFFF;
-  --static-status-valid-background: #82B962;
-  --static-status-valid-text: #000000;
-  --static-status-info-background: #8DD4CD;
-  --static-status-info-text: #000000;
-  --static-status-warning-background: #F8DA00;
-  --static-status-warning-text: #000000;
-  --static-status-error-background: #F15629;
-  --static-status-error-text: #FFFFFF;
+  --static-status-valid-primary-background: #82B962;
+  --static-status-valid-primary-text: #000000;
+  --static-status-valid-secondary-background: #82B962;
+  --static-status-valid-secondary-text: #000000;
+  --static-status-info-primary-background: #8DD4CD;
+  --static-status-info-primary-text: #000000;
+  --static-status-info-secondary-background: #8DD4CD;
+  --static-status-info-secondary-text: #000000;
+  --static-status-warning-primary-background: #F8DA00;
+  --static-status-warning-primary-text: #000000;
+  --static-status-warning-secondary-background: #F8DA00;
+  --static-status-warning-secondary-text: #000000;
+  --static-status-error-primary-background: #F15629;
+  --static-status-error-primary-text: #FFFFFF;
+  --static-status-error-secondary-background: #F15629;
+  --static-status-error-secondary-text: #FFFFFF;
   --static-zone_selection-from-background: #82B962;
   --static-zone_selection-from-text: #000000;
   --static-zone_selection-to-background: #005685;
@@ -555,21 +579,37 @@
   background-color: var(--static-background-background_accent_5-background);
   color: var(--static-background-background_accent_5-text);
 }
-.static-status-valid {
-  background-color: var(--static-status-valid-background);
-  color: var(--static-status-valid-text);
+.static-valid-primary {
+  background-color: var(--static-valid-primary-background);
+  color: var(--static-valid-primary-text);
 }
-.static-status-info {
-  background-color: var(--static-status-info-background);
-  color: var(--static-status-info-text);
+.static-valid-secondary {
+  background-color: var(--static-valid-secondary-background);
+  color: var(--static-valid-secondary-text);
 }
-.static-status-warning {
-  background-color: var(--static-status-warning-background);
-  color: var(--static-status-warning-text);
+.static-info-primary {
+  background-color: var(--static-info-primary-background);
+  color: var(--static-info-primary-text);
 }
-.static-status-error {
-  background-color: var(--static-status-error-background);
-  color: var(--static-status-error-text);
+.static-info-secondary {
+  background-color: var(--static-info-secondary-background);
+  color: var(--static-info-secondary-text);
+}
+.static-warning-primary {
+  background-color: var(--static-warning-primary-background);
+  color: var(--static-warning-primary-text);
+}
+.static-warning-secondary {
+  background-color: var(--static-warning-secondary-background);
+  color: var(--static-warning-secondary-text);
+}
+.static-error-primary {
+  background-color: var(--static-error-primary-background);
+  color: var(--static-error-primary-text);
+}
+.static-error-secondary {
+  background-color: var(--static-error-secondary-background);
+  color: var(--static-error-secondary-text);
 }
 .static-zone_selection-from {
   background-color: var(--static-zone_selection-from-background);

--- a/packages/theme/src/themes/fram-theme/theme.module.css
+++ b/packages/theme/src/themes/fram-theme/theme.module.css
@@ -46,14 +46,22 @@
   --static-background-background_accent_4-text: #000000;
   --static-background-background_accent_5-background: #007AB5;
   --static-background-background_accent_5-text: #FFFFFF;
-  --static-status-valid-background: #82B962;
-  --static-status-valid-text: #000000;
-  --static-status-info-background: #8DD4CD;
-  --static-status-info-text: #000000;
-  --static-status-warning-background: #F8DA00;
-  --static-status-warning-text: #000000;
-  --static-status-error-background: #F15629;
-  --static-status-error-text: #FFFFFF;
+  --static-status-valid-primary-background: #82B962;
+  --static-status-valid-primary-text: #000000;
+  --static-status-valid-secondary-background: #82B962;
+  --static-status-valid-secondary-text: #000000;
+  --static-status-info-primary-background: #8DD4CD;
+  --static-status-info-primary-text: #000000;
+  --static-status-info-secondary-background: #8DD4CD;
+  --static-status-info-secondary-text: #000000;
+  --static-status-warning-primary-background: #F8DA00;
+  --static-status-warning-primary-text: #000000;
+  --static-status-warning-secondary-background: #F8DA00;
+  --static-status-warning-secondary-text: #000000;
+  --static-status-error-primary-background: #F15629;
+  --static-status-error-primary-text: #FFFFFF;
+  --static-status-error-secondary-background: #F15629;
+  --static-status-error-secondary-text: #FFFFFF;
   --static-zone_selection-from-background: #82B962;
   --static-zone_selection-from-text: #000000;
   --static-zone_selection-to-background: #005685;
@@ -217,14 +225,22 @@
   --static-background-background_accent_4-text: #000000;
   --static-background-background_accent_5-background: #005685;
   --static-background-background_accent_5-text: #FFFFFF;
-  --static-status-valid-background: #82B962;
-  --static-status-valid-text: #000000;
-  --static-status-info-background: #8DD4CD;
-  --static-status-info-text: #000000;
-  --static-status-warning-background: #F8DA00;
-  --static-status-warning-text: #000000;
-  --static-status-error-background: #F15629;
-  --static-status-error-text: #FFFFFF;
+  --static-status-valid-primary-background: #82B962;
+  --static-status-valid-primary-text: #000000;
+  --static-status-valid-secondary-background: #82B962;
+  --static-status-valid-secondary-text: #000000;
+  --static-status-info-primary-background: #8DD4CD;
+  --static-status-info-primary-text: #000000;
+  --static-status-info-secondary-background: #8DD4CD;
+  --static-status-info-secondary-text: #000000;
+  --static-status-warning-primary-background: #F8DA00;
+  --static-status-warning-primary-text: #000000;
+  --static-status-warning-secondary-background: #F8DA00;
+  --static-status-warning-secondary-text: #000000;
+  --static-status-error-primary-background: #F15629;
+  --static-status-error-primary-text: #FFFFFF;
+  --static-status-error-secondary-background: #F15629;
+  --static-status-error-secondary-text: #FFFFFF;
   --static-zone_selection-from-background: #82B962;
   --static-zone_selection-from-text: #000000;
   --static-zone_selection-to-background: #005685;
@@ -388,14 +404,22 @@
   --static-background-background_accent_4-text: #000000;
   --static-background-background_accent_5-background: #005685;
   --static-background-background_accent_5-text: #FFFFFF;
-  --static-status-valid-background: #82B962;
-  --static-status-valid-text: #000000;
-  --static-status-info-background: #8DD4CD;
-  --static-status-info-text: #000000;
-  --static-status-warning-background: #F8DA00;
-  --static-status-warning-text: #000000;
-  --static-status-error-background: #F15629;
-  --static-status-error-text: #FFFFFF;
+  --static-status-valid-primary-background: #82B962;
+  --static-status-valid-primary-text: #000000;
+  --static-status-valid-secondary-background: #82B962;
+  --static-status-valid-secondary-text: #000000;
+  --static-status-info-primary-background: #8DD4CD;
+  --static-status-info-primary-text: #000000;
+  --static-status-info-secondary-background: #8DD4CD;
+  --static-status-info-secondary-text: #000000;
+  --static-status-warning-primary-background: #F8DA00;
+  --static-status-warning-primary-text: #000000;
+  --static-status-warning-secondary-background: #F8DA00;
+  --static-status-warning-secondary-text: #000000;
+  --static-status-error-primary-background: #F15629;
+  --static-status-error-primary-text: #FFFFFF;
+  --static-status-error-secondary-background: #F15629;
+  --static-status-error-secondary-text: #FFFFFF;
   --static-zone_selection-from-background: #82B962;
   --static-zone_selection-from-text: #000000;
   --static-zone_selection-to-background: #005685;
@@ -555,21 +579,37 @@
   background-color: var(--static-background-background_accent_5-background);
   color: var(--static-background-background_accent_5-text);
 }
-.static-status-valid {
-  background-color: var(--static-status-valid-background);
-  color: var(--static-status-valid-text);
+.static-valid-primary {
+  background-color: var(--static-valid-primary-background);
+  color: var(--static-valid-primary-text);
 }
-.static-status-info {
-  background-color: var(--static-status-info-background);
-  color: var(--static-status-info-text);
+.static-valid-secondary {
+  background-color: var(--static-valid-secondary-background);
+  color: var(--static-valid-secondary-text);
 }
-.static-status-warning {
-  background-color: var(--static-status-warning-background);
-  color: var(--static-status-warning-text);
+.static-info-primary {
+  background-color: var(--static-info-primary-background);
+  color: var(--static-info-primary-text);
 }
-.static-status-error {
-  background-color: var(--static-status-error-background);
-  color: var(--static-status-error-text);
+.static-info-secondary {
+  background-color: var(--static-info-secondary-background);
+  color: var(--static-info-secondary-text);
+}
+.static-warning-primary {
+  background-color: var(--static-warning-primary-background);
+  color: var(--static-warning-primary-text);
+}
+.static-warning-secondary {
+  background-color: var(--static-warning-secondary-background);
+  color: var(--static-warning-secondary-text);
+}
+.static-error-primary {
+  background-color: var(--static-error-primary-background);
+  color: var(--static-error-primary-text);
+}
+.static-error-secondary {
+  background-color: var(--static-error-secondary-background);
+  color: var(--static-error-secondary-text);
 }
 .static-zone_selection-from {
   background-color: var(--static-zone_selection-from-background);

--- a/packages/theme/src/themes/fram-theme/theme.ts
+++ b/packages/theme/src/themes/fram-theme/theme.ts
@@ -125,10 +125,22 @@ const themes: Themes = {
         background_accent_5: contrastColor('#007AB5', 'light'),
       },
       status: {
-        valid: contrastColor('#82B962', 'dark'),
-        info: contrastColor('#8DD4CD', 'dark'),
-        warning: contrastColor('#F8DA00', 'dark'),
-        error: contrastColor('#F15629', 'light'),
+        valid: {
+          primary: contrastColor('#82B962', 'dark'),
+          secondary: contrastColor('#82B962', 'dark'),
+        },
+        info: {
+          primary: contrastColor('#8DD4CD', 'dark'),
+          secondary: contrastColor('#8DD4CD', 'dark'),
+        },
+        warning: {
+          primary: contrastColor('#F8DA00', 'dark'),
+          secondary: contrastColor('#F8DA00', 'dark'),
+        },
+        error: {
+          primary: contrastColor('#F15629', 'light'),
+          secondary: contrastColor('#F15629', 'light'),
+        },
       },
       zone_selection: {
         from: contrastColor('#82B962', 'dark'),
@@ -263,10 +275,22 @@ const themes: Themes = {
       },
 
       status: {
-        valid: contrastColor('#82B962', 'dark'),
-        info: contrastColor('#8DD4CD', 'dark'),
-        warning: contrastColor('#F8DA00', 'dark'),
-        error: contrastColor('#F15629', 'light'),
+        valid: {
+          primary: contrastColor('#82B962', 'dark'),
+          secondary: contrastColor('#82B962', 'dark'),
+        },
+        info: {
+          primary: contrastColor('#8DD4CD', 'dark'),
+          secondary: contrastColor('#8DD4CD', 'dark'),
+        },
+        warning: {
+          primary: contrastColor('#F8DA00', 'dark'),
+          secondary: contrastColor('#F8DA00', 'dark'),
+        },
+        error: {
+          primary: contrastColor('#F15629', 'light'),
+          secondary: contrastColor('#F15629', 'light'),
+        },
       },
       zone_selection: {
         from: contrastColor('#82B962', 'dark'),

--- a/packages/theme/src/themes/innlandet-theme/theme.css
+++ b/packages/theme/src/themes/innlandet-theme/theme.css
@@ -46,14 +46,22 @@
   --static-background-background_accent_4-text: #000000;
   --static-background-background_accent_5-background: #A6D1D9;
   --static-background-background_accent_5-text: #000000;
-  --static-status-valid-background: #A2AD00;
-  --static-status-valid-text: #000000;
-  --static-status-info-background: #71D6E0;
-  --static-status-info-text: #000000;
-  --static-status-warning-background: #E4D700;
-  --static-status-warning-text: #000000;
-  --static-status-error-background: #A51140;
-  --static-status-error-text: #FFFFFF;
+  --static-status-valid-primary-background: #A2AD00;
+  --static-status-valid-primary-text: #000000;
+  --static-status-valid-secondary-background: #A2AD00;
+  --static-status-valid-secondary-text: #000000;
+  --static-status-info-primary-background: #71D6E0;
+  --static-status-info-primary-text: #000000;
+  --static-status-info-secondary-background: #71D6E0;
+  --static-status-info-secondary-text: #000000;
+  --static-status-warning-primary-background: #E4D700;
+  --static-status-warning-primary-text: #000000;
+  --static-status-warning-secondary-background: #E4D700;
+  --static-status-warning-secondary-text: #000000;
+  --static-status-error-primary-background: #A51140;
+  --static-status-error-primary-text: #FFFFFF;
+  --static-status-error-secondary-background: #A51140;
+  --static-status-error-secondary-text: #FFFFFF;
   --static-zone_selection-from-background: #A2AD00;
   --static-zone_selection-from-text: #000000;
   --static-zone_selection-to-background: #71D6E0;
@@ -217,14 +225,22 @@
   --static-background-background_accent_4-text: #000000;
   --static-background-background_accent_5-background: #2B343A;
   --static-background-background_accent_5-text: #FFFFFF;
-  --static-status-valid-background: #A2AD00;
-  --static-status-valid-text: #000000;
-  --static-status-info-background: #71D6E0;
-  --static-status-info-text: #000000;
-  --static-status-warning-background: #E4D700;
-  --static-status-warning-text: #000000;
-  --static-status-error-background: #A51140;
-  --static-status-error-text: #FFFFFF;
+  --static-status-valid-primary-background: #A2AD00;
+  --static-status-valid-primary-text: #000000;
+  --static-status-valid-secondary-background: #A2AD00;
+  --static-status-valid-secondary-text: #000000;
+  --static-status-info-primary-background: #71D6E0;
+  --static-status-info-primary-text: #000000;
+  --static-status-info-secondary-background: #71D6E0;
+  --static-status-info-secondary-text: #000000;
+  --static-status-warning-primary-background: #E4D700;
+  --static-status-warning-primary-text: #000000;
+  --static-status-warning-secondary-background: #E4D700;
+  --static-status-warning-secondary-text: #000000;
+  --static-status-error-primary-background: #A51140;
+  --static-status-error-primary-text: #FFFFFF;
+  --static-status-error-secondary-background: #A51140;
+  --static-status-error-secondary-text: #FFFFFF;
   --static-zone_selection-from-background: #A2AD00;
   --static-zone_selection-from-text: #000000;
   --static-zone_selection-to-background: #71D6E0;
@@ -388,14 +404,22 @@
   --static-background-background_accent_4-text: #000000;
   --static-background-background_accent_5-background: #2B343A;
   --static-background-background_accent_5-text: #FFFFFF;
-  --static-status-valid-background: #A2AD00;
-  --static-status-valid-text: #000000;
-  --static-status-info-background: #71D6E0;
-  --static-status-info-text: #000000;
-  --static-status-warning-background: #E4D700;
-  --static-status-warning-text: #000000;
-  --static-status-error-background: #A51140;
-  --static-status-error-text: #FFFFFF;
+  --static-status-valid-primary-background: #A2AD00;
+  --static-status-valid-primary-text: #000000;
+  --static-status-valid-secondary-background: #A2AD00;
+  --static-status-valid-secondary-text: #000000;
+  --static-status-info-primary-background: #71D6E0;
+  --static-status-info-primary-text: #000000;
+  --static-status-info-secondary-background: #71D6E0;
+  --static-status-info-secondary-text: #000000;
+  --static-status-warning-primary-background: #E4D700;
+  --static-status-warning-primary-text: #000000;
+  --static-status-warning-secondary-background: #E4D700;
+  --static-status-warning-secondary-text: #000000;
+  --static-status-error-primary-background: #A51140;
+  --static-status-error-primary-text: #FFFFFF;
+  --static-status-error-secondary-background: #A51140;
+  --static-status-error-secondary-text: #FFFFFF;
   --static-zone_selection-from-background: #A2AD00;
   --static-zone_selection-from-text: #000000;
   --static-zone_selection-to-background: #71D6E0;
@@ -555,21 +579,37 @@
   background-color: var(--static-background-background_accent_5-background);
   color: var(--static-background-background_accent_5-text);
 }
-.static-status-valid {
-  background-color: var(--static-status-valid-background);
-  color: var(--static-status-valid-text);
+.static-valid-primary {
+  background-color: var(--static-valid-primary-background);
+  color: var(--static-valid-primary-text);
 }
-.static-status-info {
-  background-color: var(--static-status-info-background);
-  color: var(--static-status-info-text);
+.static-valid-secondary {
+  background-color: var(--static-valid-secondary-background);
+  color: var(--static-valid-secondary-text);
 }
-.static-status-warning {
-  background-color: var(--static-status-warning-background);
-  color: var(--static-status-warning-text);
+.static-info-primary {
+  background-color: var(--static-info-primary-background);
+  color: var(--static-info-primary-text);
 }
-.static-status-error {
-  background-color: var(--static-status-error-background);
-  color: var(--static-status-error-text);
+.static-info-secondary {
+  background-color: var(--static-info-secondary-background);
+  color: var(--static-info-secondary-text);
+}
+.static-warning-primary {
+  background-color: var(--static-warning-primary-background);
+  color: var(--static-warning-primary-text);
+}
+.static-warning-secondary {
+  background-color: var(--static-warning-secondary-background);
+  color: var(--static-warning-secondary-text);
+}
+.static-error-primary {
+  background-color: var(--static-error-primary-background);
+  color: var(--static-error-primary-text);
+}
+.static-error-secondary {
+  background-color: var(--static-error-secondary-background);
+  color: var(--static-error-secondary-text);
 }
 .static-zone_selection-from {
   background-color: var(--static-zone_selection-from-background);

--- a/packages/theme/src/themes/innlandet-theme/theme.module.css
+++ b/packages/theme/src/themes/innlandet-theme/theme.module.css
@@ -46,14 +46,22 @@
   --static-background-background_accent_4-text: #000000;
   --static-background-background_accent_5-background: #A6D1D9;
   --static-background-background_accent_5-text: #000000;
-  --static-status-valid-background: #A2AD00;
-  --static-status-valid-text: #000000;
-  --static-status-info-background: #71D6E0;
-  --static-status-info-text: #000000;
-  --static-status-warning-background: #E4D700;
-  --static-status-warning-text: #000000;
-  --static-status-error-background: #A51140;
-  --static-status-error-text: #FFFFFF;
+  --static-status-valid-primary-background: #A2AD00;
+  --static-status-valid-primary-text: #000000;
+  --static-status-valid-secondary-background: #A2AD00;
+  --static-status-valid-secondary-text: #000000;
+  --static-status-info-primary-background: #71D6E0;
+  --static-status-info-primary-text: #000000;
+  --static-status-info-secondary-background: #71D6E0;
+  --static-status-info-secondary-text: #000000;
+  --static-status-warning-primary-background: #E4D700;
+  --static-status-warning-primary-text: #000000;
+  --static-status-warning-secondary-background: #E4D700;
+  --static-status-warning-secondary-text: #000000;
+  --static-status-error-primary-background: #A51140;
+  --static-status-error-primary-text: #FFFFFF;
+  --static-status-error-secondary-background: #A51140;
+  --static-status-error-secondary-text: #FFFFFF;
   --static-zone_selection-from-background: #A2AD00;
   --static-zone_selection-from-text: #000000;
   --static-zone_selection-to-background: #71D6E0;
@@ -217,14 +225,22 @@
   --static-background-background_accent_4-text: #000000;
   --static-background-background_accent_5-background: #2B343A;
   --static-background-background_accent_5-text: #FFFFFF;
-  --static-status-valid-background: #A2AD00;
-  --static-status-valid-text: #000000;
-  --static-status-info-background: #71D6E0;
-  --static-status-info-text: #000000;
-  --static-status-warning-background: #E4D700;
-  --static-status-warning-text: #000000;
-  --static-status-error-background: #A51140;
-  --static-status-error-text: #FFFFFF;
+  --static-status-valid-primary-background: #A2AD00;
+  --static-status-valid-primary-text: #000000;
+  --static-status-valid-secondary-background: #A2AD00;
+  --static-status-valid-secondary-text: #000000;
+  --static-status-info-primary-background: #71D6E0;
+  --static-status-info-primary-text: #000000;
+  --static-status-info-secondary-background: #71D6E0;
+  --static-status-info-secondary-text: #000000;
+  --static-status-warning-primary-background: #E4D700;
+  --static-status-warning-primary-text: #000000;
+  --static-status-warning-secondary-background: #E4D700;
+  --static-status-warning-secondary-text: #000000;
+  --static-status-error-primary-background: #A51140;
+  --static-status-error-primary-text: #FFFFFF;
+  --static-status-error-secondary-background: #A51140;
+  --static-status-error-secondary-text: #FFFFFF;
   --static-zone_selection-from-background: #A2AD00;
   --static-zone_selection-from-text: #000000;
   --static-zone_selection-to-background: #71D6E0;
@@ -388,14 +404,22 @@
   --static-background-background_accent_4-text: #000000;
   --static-background-background_accent_5-background: #2B343A;
   --static-background-background_accent_5-text: #FFFFFF;
-  --static-status-valid-background: #A2AD00;
-  --static-status-valid-text: #000000;
-  --static-status-info-background: #71D6E0;
-  --static-status-info-text: #000000;
-  --static-status-warning-background: #E4D700;
-  --static-status-warning-text: #000000;
-  --static-status-error-background: #A51140;
-  --static-status-error-text: #FFFFFF;
+  --static-status-valid-primary-background: #A2AD00;
+  --static-status-valid-primary-text: #000000;
+  --static-status-valid-secondary-background: #A2AD00;
+  --static-status-valid-secondary-text: #000000;
+  --static-status-info-primary-background: #71D6E0;
+  --static-status-info-primary-text: #000000;
+  --static-status-info-secondary-background: #71D6E0;
+  --static-status-info-secondary-text: #000000;
+  --static-status-warning-primary-background: #E4D700;
+  --static-status-warning-primary-text: #000000;
+  --static-status-warning-secondary-background: #E4D700;
+  --static-status-warning-secondary-text: #000000;
+  --static-status-error-primary-background: #A51140;
+  --static-status-error-primary-text: #FFFFFF;
+  --static-status-error-secondary-background: #A51140;
+  --static-status-error-secondary-text: #FFFFFF;
   --static-zone_selection-from-background: #A2AD00;
   --static-zone_selection-from-text: #000000;
   --static-zone_selection-to-background: #71D6E0;
@@ -555,21 +579,37 @@
   background-color: var(--static-background-background_accent_5-background);
   color: var(--static-background-background_accent_5-text);
 }
-.static-status-valid {
-  background-color: var(--static-status-valid-background);
-  color: var(--static-status-valid-text);
+.static-valid-primary {
+  background-color: var(--static-valid-primary-background);
+  color: var(--static-valid-primary-text);
 }
-.static-status-info {
-  background-color: var(--static-status-info-background);
-  color: var(--static-status-info-text);
+.static-valid-secondary {
+  background-color: var(--static-valid-secondary-background);
+  color: var(--static-valid-secondary-text);
 }
-.static-status-warning {
-  background-color: var(--static-status-warning-background);
-  color: var(--static-status-warning-text);
+.static-info-primary {
+  background-color: var(--static-info-primary-background);
+  color: var(--static-info-primary-text);
 }
-.static-status-error {
-  background-color: var(--static-status-error-background);
-  color: var(--static-status-error-text);
+.static-info-secondary {
+  background-color: var(--static-info-secondary-background);
+  color: var(--static-info-secondary-text);
+}
+.static-warning-primary {
+  background-color: var(--static-warning-primary-background);
+  color: var(--static-warning-primary-text);
+}
+.static-warning-secondary {
+  background-color: var(--static-warning-secondary-background);
+  color: var(--static-warning-secondary-text);
+}
+.static-error-primary {
+  background-color: var(--static-error-primary-background);
+  color: var(--static-error-primary-text);
+}
+.static-error-secondary {
+  background-color: var(--static-error-secondary-background);
+  color: var(--static-error-secondary-text);
 }
 .static-zone_selection-from {
   background-color: var(--static-zone_selection-from-background);

--- a/packages/theme/src/themes/innlandet-theme/theme.ts
+++ b/packages/theme/src/themes/innlandet-theme/theme.ts
@@ -247,10 +247,22 @@ const themes: Themes = {
         background_accent_5: baseColors.blue_200,
       },
       status: {
-        valid: baseColors.green_300,
-        info: baseColors.cyan_200,
-        warning: baseColors.yellow_200,
-        error: baseColors.red_600,
+        valid: {
+          primary: baseColors.green_300,
+          secondary: baseColors.green_300,
+        },
+        info: {
+          primary: baseColors.cyan_200,
+          secondary: baseColors.cyan_200,
+        },
+        warning: {
+          primary: baseColors.yellow_200,
+          secondary: baseColors.yellow_200,
+        },
+        error: {
+          primary: baseColors.red_600,
+          secondary: baseColors.red_600,
+        },
       },
       zone_selection: {
         from: baseColors.green_300,
@@ -386,10 +398,22 @@ const themes: Themes = {
       },
 
       status: {
-        valid: baseColors.green_300,
-        info: baseColors.cyan_200,
-        warning: baseColors.yellow_200,
-        error: baseColors.red_600,
+        valid: {
+          primary: baseColors.green_300,
+          secondary: baseColors.green_300,
+        },
+        info: {
+          primary: baseColors.cyan_200,
+          secondary: baseColors.cyan_200,
+        },
+        warning: {
+          primary: baseColors.yellow_200,
+          secondary: baseColors.yellow_200,
+        },
+        error: {
+          primary: baseColors.red_600,
+          secondary: baseColors.red_600,
+        },
       },
       zone_selection: {
         from: baseColors.green_300,

--- a/packages/theme/src/themes/nfk-theme/theme.css
+++ b/packages/theme/src/themes/nfk-theme/theme.css
@@ -46,14 +46,22 @@
   --static-background-background_accent_4-text: #003441;
   --static-background-background_accent_5-background: #FFFFFF;
   --static-background-background_accent_5-text: #003441;
-  --static-status-valid-background: #7FDABB;
-  --static-status-valid-text: #003441;
-  --static-status-info-background: #99CDDA;
-  --static-status-info-text: #003441;
-  --static-status-warning-background: #FCBA63;
-  --static-status-warning-text: #003441;
-  --static-status-error-background: #A61419;
-  --static-status-error-text: #FFFFFF;
+  --static-status-valid-primary-background: #7FDABB;
+  --static-status-valid-primary-text: #003441;
+  --static-status-valid-secondary-background: #7FDABB;
+  --static-status-valid-secondary-text: #003441;
+  --static-status-info-primary-background: #99CDDA;
+  --static-status-info-primary-text: #003441;
+  --static-status-info-secondary-background: #99CDDA;
+  --static-status-info-secondary-text: #003441;
+  --static-status-warning-primary-background: #FCBA63;
+  --static-status-warning-primary-text: #003441;
+  --static-status-warning-secondary-background: #FCBA63;
+  --static-status-warning-secondary-text: #003441;
+  --static-status-error-primary-background: #A61419;
+  --static-status-error-primary-text: #FFFFFF;
+  --static-status-error-secondary-background: #A61419;
+  --static-status-error-secondary-text: #FFFFFF;
   --static-zone_selection-from-background: #FF7E81;
   --static-zone_selection-from-text: #003441;
   --static-zone_selection-to-background: #FF282E;
@@ -217,14 +225,22 @@
   --static-background-background_accent_4-text: #FFFFFF;
   --static-background-background_accent_5-background: #000000;
   --static-background-background_accent_5-text: #FFFFFF;
-  --static-status-valid-background: #7FDABB;
-  --static-status-valid-text: #003441;
-  --static-status-info-background: #99CDDA;
-  --static-status-info-text: #003441;
-  --static-status-warning-background: #FCBA63;
-  --static-status-warning-text: #003441;
-  --static-status-error-background: #BE161D;
-  --static-status-error-text: #FFFFFF;
+  --static-status-valid-primary-background: #7FDABB;
+  --static-status-valid-primary-text: #003441;
+  --static-status-valid-secondary-background: #7FDABB;
+  --static-status-valid-secondary-text: #003441;
+  --static-status-info-primary-background: #99CDDA;
+  --static-status-info-primary-text: #003441;
+  --static-status-info-secondary-background: #99CDDA;
+  --static-status-info-secondary-text: #003441;
+  --static-status-warning-primary-background: #FCBA63;
+  --static-status-warning-primary-text: #003441;
+  --static-status-warning-secondary-background: #FCBA63;
+  --static-status-warning-secondary-text: #003441;
+  --static-status-error-primary-background: #BE161D;
+  --static-status-error-primary-text: #FFFFFF;
+  --static-status-error-secondary-background: #BE161D;
+  --static-status-error-secondary-text: #FFFFFF;
   --static-zone_selection-from-background: #FF7E81;
   --static-zone_selection-from-text: #003441;
   --static-zone_selection-to-background: #FF282E;
@@ -388,14 +404,22 @@
   --static-background-background_accent_4-text: #FFFFFF;
   --static-background-background_accent_5-background: #000000;
   --static-background-background_accent_5-text: #FFFFFF;
-  --static-status-valid-background: #7FDABB;
-  --static-status-valid-text: #003441;
-  --static-status-info-background: #99CDDA;
-  --static-status-info-text: #003441;
-  --static-status-warning-background: #FCBA63;
-  --static-status-warning-text: #003441;
-  --static-status-error-background: #BE161D;
-  --static-status-error-text: #FFFFFF;
+  --static-status-valid-primary-background: #7FDABB;
+  --static-status-valid-primary-text: #003441;
+  --static-status-valid-secondary-background: #7FDABB;
+  --static-status-valid-secondary-text: #003441;
+  --static-status-info-primary-background: #99CDDA;
+  --static-status-info-primary-text: #003441;
+  --static-status-info-secondary-background: #99CDDA;
+  --static-status-info-secondary-text: #003441;
+  --static-status-warning-primary-background: #FCBA63;
+  --static-status-warning-primary-text: #003441;
+  --static-status-warning-secondary-background: #FCBA63;
+  --static-status-warning-secondary-text: #003441;
+  --static-status-error-primary-background: #BE161D;
+  --static-status-error-primary-text: #FFFFFF;
+  --static-status-error-secondary-background: #BE161D;
+  --static-status-error-secondary-text: #FFFFFF;
   --static-zone_selection-from-background: #FF7E81;
   --static-zone_selection-from-text: #003441;
   --static-zone_selection-to-background: #FF282E;
@@ -555,21 +579,37 @@
   background-color: var(--static-background-background_accent_5-background);
   color: var(--static-background-background_accent_5-text);
 }
-.static-status-valid {
-  background-color: var(--static-status-valid-background);
-  color: var(--static-status-valid-text);
+.static-valid-primary {
+  background-color: var(--static-valid-primary-background);
+  color: var(--static-valid-primary-text);
 }
-.static-status-info {
-  background-color: var(--static-status-info-background);
-  color: var(--static-status-info-text);
+.static-valid-secondary {
+  background-color: var(--static-valid-secondary-background);
+  color: var(--static-valid-secondary-text);
 }
-.static-status-warning {
-  background-color: var(--static-status-warning-background);
-  color: var(--static-status-warning-text);
+.static-info-primary {
+  background-color: var(--static-info-primary-background);
+  color: var(--static-info-primary-text);
 }
-.static-status-error {
-  background-color: var(--static-status-error-background);
-  color: var(--static-status-error-text);
+.static-info-secondary {
+  background-color: var(--static-info-secondary-background);
+  color: var(--static-info-secondary-text);
+}
+.static-warning-primary {
+  background-color: var(--static-warning-primary-background);
+  color: var(--static-warning-primary-text);
+}
+.static-warning-secondary {
+  background-color: var(--static-warning-secondary-background);
+  color: var(--static-warning-secondary-text);
+}
+.static-error-primary {
+  background-color: var(--static-error-primary-background);
+  color: var(--static-error-primary-text);
+}
+.static-error-secondary {
+  background-color: var(--static-error-secondary-background);
+  color: var(--static-error-secondary-text);
 }
 .static-zone_selection-from {
   background-color: var(--static-zone_selection-from-background);

--- a/packages/theme/src/themes/nfk-theme/theme.module.css
+++ b/packages/theme/src/themes/nfk-theme/theme.module.css
@@ -46,14 +46,22 @@
   --static-background-background_accent_4-text: #003441;
   --static-background-background_accent_5-background: #FFFFFF;
   --static-background-background_accent_5-text: #003441;
-  --static-status-valid-background: #7FDABB;
-  --static-status-valid-text: #003441;
-  --static-status-info-background: #99CDDA;
-  --static-status-info-text: #003441;
-  --static-status-warning-background: #FCBA63;
-  --static-status-warning-text: #003441;
-  --static-status-error-background: #A61419;
-  --static-status-error-text: #FFFFFF;
+  --static-status-valid-primary-background: #7FDABB;
+  --static-status-valid-primary-text: #003441;
+  --static-status-valid-secondary-background: #7FDABB;
+  --static-status-valid-secondary-text: #003441;
+  --static-status-info-primary-background: #99CDDA;
+  --static-status-info-primary-text: #003441;
+  --static-status-info-secondary-background: #99CDDA;
+  --static-status-info-secondary-text: #003441;
+  --static-status-warning-primary-background: #FCBA63;
+  --static-status-warning-primary-text: #003441;
+  --static-status-warning-secondary-background: #FCBA63;
+  --static-status-warning-secondary-text: #003441;
+  --static-status-error-primary-background: #A61419;
+  --static-status-error-primary-text: #FFFFFF;
+  --static-status-error-secondary-background: #A61419;
+  --static-status-error-secondary-text: #FFFFFF;
   --static-zone_selection-from-background: #FF7E81;
   --static-zone_selection-from-text: #003441;
   --static-zone_selection-to-background: #FF282E;
@@ -217,14 +225,22 @@
   --static-background-background_accent_4-text: #FFFFFF;
   --static-background-background_accent_5-background: #000000;
   --static-background-background_accent_5-text: #FFFFFF;
-  --static-status-valid-background: #7FDABB;
-  --static-status-valid-text: #003441;
-  --static-status-info-background: #99CDDA;
-  --static-status-info-text: #003441;
-  --static-status-warning-background: #FCBA63;
-  --static-status-warning-text: #003441;
-  --static-status-error-background: #BE161D;
-  --static-status-error-text: #FFFFFF;
+  --static-status-valid-primary-background: #7FDABB;
+  --static-status-valid-primary-text: #003441;
+  --static-status-valid-secondary-background: #7FDABB;
+  --static-status-valid-secondary-text: #003441;
+  --static-status-info-primary-background: #99CDDA;
+  --static-status-info-primary-text: #003441;
+  --static-status-info-secondary-background: #99CDDA;
+  --static-status-info-secondary-text: #003441;
+  --static-status-warning-primary-background: #FCBA63;
+  --static-status-warning-primary-text: #003441;
+  --static-status-warning-secondary-background: #FCBA63;
+  --static-status-warning-secondary-text: #003441;
+  --static-status-error-primary-background: #BE161D;
+  --static-status-error-primary-text: #FFFFFF;
+  --static-status-error-secondary-background: #BE161D;
+  --static-status-error-secondary-text: #FFFFFF;
   --static-zone_selection-from-background: #FF7E81;
   --static-zone_selection-from-text: #003441;
   --static-zone_selection-to-background: #FF282E;
@@ -388,14 +404,22 @@
   --static-background-background_accent_4-text: #FFFFFF;
   --static-background-background_accent_5-background: #000000;
   --static-background-background_accent_5-text: #FFFFFF;
-  --static-status-valid-background: #7FDABB;
-  --static-status-valid-text: #003441;
-  --static-status-info-background: #99CDDA;
-  --static-status-info-text: #003441;
-  --static-status-warning-background: #FCBA63;
-  --static-status-warning-text: #003441;
-  --static-status-error-background: #BE161D;
-  --static-status-error-text: #FFFFFF;
+  --static-status-valid-primary-background: #7FDABB;
+  --static-status-valid-primary-text: #003441;
+  --static-status-valid-secondary-background: #7FDABB;
+  --static-status-valid-secondary-text: #003441;
+  --static-status-info-primary-background: #99CDDA;
+  --static-status-info-primary-text: #003441;
+  --static-status-info-secondary-background: #99CDDA;
+  --static-status-info-secondary-text: #003441;
+  --static-status-warning-primary-background: #FCBA63;
+  --static-status-warning-primary-text: #003441;
+  --static-status-warning-secondary-background: #FCBA63;
+  --static-status-warning-secondary-text: #003441;
+  --static-status-error-primary-background: #BE161D;
+  --static-status-error-primary-text: #FFFFFF;
+  --static-status-error-secondary-background: #BE161D;
+  --static-status-error-secondary-text: #FFFFFF;
   --static-zone_selection-from-background: #FF7E81;
   --static-zone_selection-from-text: #003441;
   --static-zone_selection-to-background: #FF282E;
@@ -555,21 +579,37 @@
   background-color: var(--static-background-background_accent_5-background);
   color: var(--static-background-background_accent_5-text);
 }
-.static-status-valid {
-  background-color: var(--static-status-valid-background);
-  color: var(--static-status-valid-text);
+.static-valid-primary {
+  background-color: var(--static-valid-primary-background);
+  color: var(--static-valid-primary-text);
 }
-.static-status-info {
-  background-color: var(--static-status-info-background);
-  color: var(--static-status-info-text);
+.static-valid-secondary {
+  background-color: var(--static-valid-secondary-background);
+  color: var(--static-valid-secondary-text);
 }
-.static-status-warning {
-  background-color: var(--static-status-warning-background);
-  color: var(--static-status-warning-text);
+.static-info-primary {
+  background-color: var(--static-info-primary-background);
+  color: var(--static-info-primary-text);
 }
-.static-status-error {
-  background-color: var(--static-status-error-background);
-  color: var(--static-status-error-text);
+.static-info-secondary {
+  background-color: var(--static-info-secondary-background);
+  color: var(--static-info-secondary-text);
+}
+.static-warning-primary {
+  background-color: var(--static-warning-primary-background);
+  color: var(--static-warning-primary-text);
+}
+.static-warning-secondary {
+  background-color: var(--static-warning-secondary-background);
+  color: var(--static-warning-secondary-text);
+}
+.static-error-primary {
+  background-color: var(--static-error-primary-background);
+  color: var(--static-error-primary-text);
+}
+.static-error-secondary {
+  background-color: var(--static-error-secondary-background);
+  color: var(--static-error-secondary-text);
 }
 .static-zone_selection-from {
   background-color: var(--static-zone_selection-from-background);

--- a/packages/theme/src/themes/nfk-theme/theme.ts
+++ b/packages/theme/src/themes/nfk-theme/theme.ts
@@ -130,10 +130,22 @@ const themes: Themes = {
         background_accent_5: contrastColor('#FFFFFF', 'dark'),
       },
       status: {
-        valid: contrastColor('#7FDABB', 'dark'),
-        info: contrastColor('#99CDDA', 'dark'),
-        warning: contrastColor('#FCBA63', 'dark'),
-        error: contrastColor('#A61419', 'light'),
+        valid: {
+          primary: contrastColor('#7FDABB', 'dark'),
+          secondary: contrastColor('#7FDABB', 'dark'),
+        },
+        info: {
+          primary: contrastColor('#99CDDA', 'dark'),
+          secondary: contrastColor('#99CDDA', 'dark'),
+        },
+        warning: {
+          primary: contrastColor('#FCBA63', 'dark'),
+          secondary: contrastColor('#FCBA63', 'dark'),
+        },
+        error: {
+          primary: contrastColor('#A61419', 'light'),
+          secondary: contrastColor('#A61419', 'light'),
+        },
       },
       zone_selection: {
         from: contrastColor('#FF7E81', 'dark'),
@@ -267,10 +279,22 @@ const themes: Themes = {
         background_accent_5: contrastColor('#000000', 'light'),
       },
       status: {
-        valid: contrastColor('#7FDABB', 'dark'),
-        info: contrastColor('#99CDDA', 'dark'),
-        warning: contrastColor('#FCBA63', 'dark'),
-        error: contrastColor('#BE161D', 'light'),
+        valid: {
+          primary: contrastColor('#7FDABB', 'dark'),
+          secondary: contrastColor('#7FDABB', 'dark'),
+        },
+        info: {
+          primary: contrastColor('#99CDDA', 'dark'),
+          secondary: contrastColor('#99CDDA', 'dark'),
+        },
+        warning: {
+          primary: contrastColor('#FCBA63', 'dark'),
+          secondary: contrastColor('#FCBA63', 'dark'),
+        },
+        error: {
+          primary: contrastColor('#BE161D', 'light'),
+          secondary: contrastColor('#BE161D', 'light'),
+        },
       },
       zone_selection: {
         from: contrastColor('#FF7E81', 'dark'),

--- a/packages/theme/src/themes/troms-theme/theme.css
+++ b/packages/theme/src/themes/troms-theme/theme.css
@@ -46,14 +46,22 @@
   --static-background-background_accent_4-text: #000000;
   --static-background-background_accent_5-background: #F09060;
   --static-background-background_accent_5-text: #000000;
-  --static-status-valid-background: #6B9956;
-  --static-status-valid-text: #000000;
-  --static-status-info-background: #546AD6;
-  --static-status-info-text: #FFFFFF;
-  --static-status-warning-background: #E6D220;
-  --static-status-warning-text: #000000;
-  --static-status-error-background: #DB6364;
-  --static-status-error-text: #000000;
+  --static-status-valid-primary-background: #6B9956;
+  --static-status-valid-primary-text: #000000;
+  --static-status-valid-secondary-background: #6B9956;
+  --static-status-valid-secondary-text: #000000;
+  --static-status-info-primary-background: #546AD6;
+  --static-status-info-primary-text: #FFFFFF;
+  --static-status-info-secondary-background: #546AD6;
+  --static-status-info-secondary-text: #FFFFFF;
+  --static-status-warning-primary-background: #E6D220;
+  --static-status-warning-primary-text: #000000;
+  --static-status-warning-secondary-background: #E6D220;
+  --static-status-warning-secondary-text: #000000;
+  --static-status-error-primary-background: #DB6364;
+  --static-status-error-primary-text: #000000;
+  --static-status-error-secondary-background: #DB6364;
+  --static-status-error-secondary-text: #000000;
   --static-zone_selection-from-background: #E7FFDD;
   --static-zone_selection-from-text: #000000;
   --static-zone_selection-to-background: #D7FDFF;
@@ -217,14 +225,22 @@
   --static-background-background_accent_4-text: #000000;
   --static-background-background_accent_5-background: #F09060;
   --static-background-background_accent_5-text: #000000;
-  --static-status-valid-background: #6B9956;
-  --static-status-valid-text: #000000;
-  --static-status-info-background: #546AD6;
-  --static-status-info-text: #FFFFFF;
-  --static-status-warning-background: #E6D220;
-  --static-status-warning-text: #000000;
-  --static-status-error-background: #DB6364;
-  --static-status-error-text: #000000;
+  --static-status-valid-primary-background: #6B9956;
+  --static-status-valid-primary-text: #000000;
+  --static-status-valid-secondary-background: #6B9956;
+  --static-status-valid-secondary-text: #000000;
+  --static-status-info-primary-background: #546AD6;
+  --static-status-info-primary-text: #FFFFFF;
+  --static-status-info-secondary-background: #546AD6;
+  --static-status-info-secondary-text: #FFFFFF;
+  --static-status-warning-primary-background: #E6D220;
+  --static-status-warning-primary-text: #000000;
+  --static-status-warning-secondary-background: #E6D220;
+  --static-status-warning-secondary-text: #000000;
+  --static-status-error-primary-background: #DB6364;
+  --static-status-error-primary-text: #000000;
+  --static-status-error-secondary-background: #DB6364;
+  --static-status-error-secondary-text: #000000;
   --static-zone_selection-from-background: #E7FFDD;
   --static-zone_selection-from-text: #000000;
   --static-zone_selection-to-background: #D7FDFF;
@@ -388,14 +404,22 @@
   --static-background-background_accent_4-text: #000000;
   --static-background-background_accent_5-background: #F09060;
   --static-background-background_accent_5-text: #000000;
-  --static-status-valid-background: #6B9956;
-  --static-status-valid-text: #000000;
-  --static-status-info-background: #546AD6;
-  --static-status-info-text: #FFFFFF;
-  --static-status-warning-background: #E6D220;
-  --static-status-warning-text: #000000;
-  --static-status-error-background: #DB6364;
-  --static-status-error-text: #000000;
+  --static-status-valid-primary-background: #6B9956;
+  --static-status-valid-primary-text: #000000;
+  --static-status-valid-secondary-background: #6B9956;
+  --static-status-valid-secondary-text: #000000;
+  --static-status-info-primary-background: #546AD6;
+  --static-status-info-primary-text: #FFFFFF;
+  --static-status-info-secondary-background: #546AD6;
+  --static-status-info-secondary-text: #FFFFFF;
+  --static-status-warning-primary-background: #E6D220;
+  --static-status-warning-primary-text: #000000;
+  --static-status-warning-secondary-background: #E6D220;
+  --static-status-warning-secondary-text: #000000;
+  --static-status-error-primary-background: #DB6364;
+  --static-status-error-primary-text: #000000;
+  --static-status-error-secondary-background: #DB6364;
+  --static-status-error-secondary-text: #000000;
   --static-zone_selection-from-background: #E7FFDD;
   --static-zone_selection-from-text: #000000;
   --static-zone_selection-to-background: #D7FDFF;
@@ -555,21 +579,37 @@
   background-color: var(--static-background-background_accent_5-background);
   color: var(--static-background-background_accent_5-text);
 }
-.static-status-valid {
-  background-color: var(--static-status-valid-background);
-  color: var(--static-status-valid-text);
+.static-valid-primary {
+  background-color: var(--static-valid-primary-background);
+  color: var(--static-valid-primary-text);
 }
-.static-status-info {
-  background-color: var(--static-status-info-background);
-  color: var(--static-status-info-text);
+.static-valid-secondary {
+  background-color: var(--static-valid-secondary-background);
+  color: var(--static-valid-secondary-text);
 }
-.static-status-warning {
-  background-color: var(--static-status-warning-background);
-  color: var(--static-status-warning-text);
+.static-info-primary {
+  background-color: var(--static-info-primary-background);
+  color: var(--static-info-primary-text);
 }
-.static-status-error {
-  background-color: var(--static-status-error-background);
-  color: var(--static-status-error-text);
+.static-info-secondary {
+  background-color: var(--static-info-secondary-background);
+  color: var(--static-info-secondary-text);
+}
+.static-warning-primary {
+  background-color: var(--static-warning-primary-background);
+  color: var(--static-warning-primary-text);
+}
+.static-warning-secondary {
+  background-color: var(--static-warning-secondary-background);
+  color: var(--static-warning-secondary-text);
+}
+.static-error-primary {
+  background-color: var(--static-error-primary-background);
+  color: var(--static-error-primary-text);
+}
+.static-error-secondary {
+  background-color: var(--static-error-secondary-background);
+  color: var(--static-error-secondary-text);
 }
 .static-zone_selection-from {
   background-color: var(--static-zone_selection-from-background);

--- a/packages/theme/src/themes/troms-theme/theme.module.css
+++ b/packages/theme/src/themes/troms-theme/theme.module.css
@@ -46,14 +46,22 @@
   --static-background-background_accent_4-text: #000000;
   --static-background-background_accent_5-background: #F09060;
   --static-background-background_accent_5-text: #000000;
-  --static-status-valid-background: #6B9956;
-  --static-status-valid-text: #000000;
-  --static-status-info-background: #546AD6;
-  --static-status-info-text: #FFFFFF;
-  --static-status-warning-background: #E6D220;
-  --static-status-warning-text: #000000;
-  --static-status-error-background: #DB6364;
-  --static-status-error-text: #000000;
+  --static-status-valid-primary-background: #6B9956;
+  --static-status-valid-primary-text: #000000;
+  --static-status-valid-secondary-background: #6B9956;
+  --static-status-valid-secondary-text: #000000;
+  --static-status-info-primary-background: #546AD6;
+  --static-status-info-primary-text: #FFFFFF;
+  --static-status-info-secondary-background: #546AD6;
+  --static-status-info-secondary-text: #FFFFFF;
+  --static-status-warning-primary-background: #E6D220;
+  --static-status-warning-primary-text: #000000;
+  --static-status-warning-secondary-background: #E6D220;
+  --static-status-warning-secondary-text: #000000;
+  --static-status-error-primary-background: #DB6364;
+  --static-status-error-primary-text: #000000;
+  --static-status-error-secondary-background: #DB6364;
+  --static-status-error-secondary-text: #000000;
   --static-zone_selection-from-background: #E7FFDD;
   --static-zone_selection-from-text: #000000;
   --static-zone_selection-to-background: #D7FDFF;
@@ -217,14 +225,22 @@
   --static-background-background_accent_4-text: #000000;
   --static-background-background_accent_5-background: #F09060;
   --static-background-background_accent_5-text: #000000;
-  --static-status-valid-background: #6B9956;
-  --static-status-valid-text: #000000;
-  --static-status-info-background: #546AD6;
-  --static-status-info-text: #FFFFFF;
-  --static-status-warning-background: #E6D220;
-  --static-status-warning-text: #000000;
-  --static-status-error-background: #DB6364;
-  --static-status-error-text: #000000;
+  --static-status-valid-primary-background: #6B9956;
+  --static-status-valid-primary-text: #000000;
+  --static-status-valid-secondary-background: #6B9956;
+  --static-status-valid-secondary-text: #000000;
+  --static-status-info-primary-background: #546AD6;
+  --static-status-info-primary-text: #FFFFFF;
+  --static-status-info-secondary-background: #546AD6;
+  --static-status-info-secondary-text: #FFFFFF;
+  --static-status-warning-primary-background: #E6D220;
+  --static-status-warning-primary-text: #000000;
+  --static-status-warning-secondary-background: #E6D220;
+  --static-status-warning-secondary-text: #000000;
+  --static-status-error-primary-background: #DB6364;
+  --static-status-error-primary-text: #000000;
+  --static-status-error-secondary-background: #DB6364;
+  --static-status-error-secondary-text: #000000;
   --static-zone_selection-from-background: #E7FFDD;
   --static-zone_selection-from-text: #000000;
   --static-zone_selection-to-background: #D7FDFF;
@@ -388,14 +404,22 @@
   --static-background-background_accent_4-text: #000000;
   --static-background-background_accent_5-background: #F09060;
   --static-background-background_accent_5-text: #000000;
-  --static-status-valid-background: #6B9956;
-  --static-status-valid-text: #000000;
-  --static-status-info-background: #546AD6;
-  --static-status-info-text: #FFFFFF;
-  --static-status-warning-background: #E6D220;
-  --static-status-warning-text: #000000;
-  --static-status-error-background: #DB6364;
-  --static-status-error-text: #000000;
+  --static-status-valid-primary-background: #6B9956;
+  --static-status-valid-primary-text: #000000;
+  --static-status-valid-secondary-background: #6B9956;
+  --static-status-valid-secondary-text: #000000;
+  --static-status-info-primary-background: #546AD6;
+  --static-status-info-primary-text: #FFFFFF;
+  --static-status-info-secondary-background: #546AD6;
+  --static-status-info-secondary-text: #FFFFFF;
+  --static-status-warning-primary-background: #E6D220;
+  --static-status-warning-primary-text: #000000;
+  --static-status-warning-secondary-background: #E6D220;
+  --static-status-warning-secondary-text: #000000;
+  --static-status-error-primary-background: #DB6364;
+  --static-status-error-primary-text: #000000;
+  --static-status-error-secondary-background: #DB6364;
+  --static-status-error-secondary-text: #000000;
   --static-zone_selection-from-background: #E7FFDD;
   --static-zone_selection-from-text: #000000;
   --static-zone_selection-to-background: #D7FDFF;
@@ -555,21 +579,37 @@
   background-color: var(--static-background-background_accent_5-background);
   color: var(--static-background-background_accent_5-text);
 }
-.static-status-valid {
-  background-color: var(--static-status-valid-background);
-  color: var(--static-status-valid-text);
+.static-valid-primary {
+  background-color: var(--static-valid-primary-background);
+  color: var(--static-valid-primary-text);
 }
-.static-status-info {
-  background-color: var(--static-status-info-background);
-  color: var(--static-status-info-text);
+.static-valid-secondary {
+  background-color: var(--static-valid-secondary-background);
+  color: var(--static-valid-secondary-text);
 }
-.static-status-warning {
-  background-color: var(--static-status-warning-background);
-  color: var(--static-status-warning-text);
+.static-info-primary {
+  background-color: var(--static-info-primary-background);
+  color: var(--static-info-primary-text);
 }
-.static-status-error {
-  background-color: var(--static-status-error-background);
-  color: var(--static-status-error-text);
+.static-info-secondary {
+  background-color: var(--static-info-secondary-background);
+  color: var(--static-info-secondary-text);
+}
+.static-warning-primary {
+  background-color: var(--static-warning-primary-background);
+  color: var(--static-warning-primary-text);
+}
+.static-warning-secondary {
+  background-color: var(--static-warning-secondary-background);
+  color: var(--static-warning-secondary-text);
+}
+.static-error-primary {
+  background-color: var(--static-error-primary-background);
+  color: var(--static-error-primary-text);
+}
+.static-error-secondary {
+  background-color: var(--static-error-secondary-background);
+  color: var(--static-error-secondary-text);
 }
 .static-zone_selection-from {
   background-color: var(--static-zone_selection-from-background);

--- a/packages/theme/src/themes/troms-theme/theme.ts
+++ b/packages/theme/src/themes/troms-theme/theme.ts
@@ -254,10 +254,22 @@ const themes: Themes = {
         background_accent_5: baseColors.orange_300,
       },
       status: {
-        valid: baseColors.green_700,
-        info: baseColors.blue_300,
-        warning: baseColors.yellow_400,
-        error: baseColors.red_300,
+        valid: {
+          primary: baseColors.green_700,
+          secondary: baseColors.green_700,
+        },
+        info: {
+          primary: baseColors.blue_300,
+          secondary: baseColors.blue_300,
+        },
+        warning: {
+          primary: baseColors.yellow_400,
+          secondary: baseColors.yellow_400,
+        },
+        error: {
+          primary: baseColors.red_300,
+          secondary: baseColors.red_300,
+        },
       },
       zone_selection: {
         from: baseColors.green_300,
@@ -393,10 +405,22 @@ const themes: Themes = {
       },
 
       status: {
-        valid: baseColors.green_700,
-        info: baseColors.blue_300,
-        warning: baseColors.yellow_400,
-        error: baseColors.red_300,
+        valid: {
+          primary: baseColors.green_700,
+          secondary: baseColors.green_700,
+        },
+        info: {
+          primary: baseColors.blue_300,
+          secondary: baseColors.blue_300,
+        },
+        warning: {
+          primary: baseColors.yellow_400,
+          secondary: baseColors.yellow_400,
+        },
+        error: {
+          primary: baseColors.red_300,
+          secondary: baseColors.red_300,
+        },
       },
       zone_selection: {
         from: baseColors.green_300,


### PR DESCRIPTION
related to
- https://github.com/AtB-AS/kundevendt/issues/15379
- https://github.com/AtB-AS/kundevendt/issues/18138
- https://github.com/AtB-AS/kundevendt/issues/18136

also partly related to https://github.com/AtB-AS/kundevendt/issues/18132 (new label color)

This PR will update the color for `Status Colors`, as explained on the issues I linked above, there is a new color system for `MessageInfoBox`, and this results in the change below:

#### From
```
export type ContrastColor = {
  background: string;
  text: string;
};

status: {
  valid: ContrastColor;
  info: ContrastColor;
  warning: ContrastColor;
  error: ContrastColor;
};
```

#### To

```
export type ContrastColor = {
  background: string;
  text: string;
};

export type StatusColor = {
  primary: ContrastColor;
  secondary: ContrastColor;
};

status: {
  valid: StatusColor;
  info: StatusColor;
  warning: StatusColor;
  error: StatusColor;
};
```

As a result of this change, there will be an update PR for both app and webshop to refer to the new colors. These new PRs will only update the reference of these colors. 

For example, currently we have this reference in app: 
```
static.status.info.background
```

After this PR is merged and changes are published, then when we use the new package in the app, we will have to change the reference to: 
```
static.status.info.primary.background
```

-----

I have updated the colors for AtB based on the Figma design (and added missing colors `cyan_50`, `yellow_50`, `red_50`). For the OMS-partners, I kept both `primary` and `secondary` colors the same, so that when we change the component, the visuals will not change for the OMS-partners.

Also, I think this is a major version bump since this is a breaking change?