### PR TITLE
feat: revert atb color change

### DIFF
--- a/packages/theme/src/themes/atb-theme/theme.ts
+++ b/packages/theme/src/themes/atb-theme/theme.ts
@@ -256,20 +256,20 @@ const themes: Themes = {
     },
     status: {
       valid: {
-        primary: baseColors.green_400,
-        secondary: baseColors.green_100,
+        primary: baseColors.green_300,
+        secondary: baseColors.green_300,
       },
       info: {
-        primary: baseColors.blue_500,
-        secondary: baseColors.blue_50,
+        primary: baseColors.cyan_200,
+        secondary: baseColors.cyan_200,
       },
       warning: {
         primary: baseColors.yellow_200,
-        secondary: baseColors.yellow_50,
+        secondary: baseColors.yellow_200,
       },
       error: {
-        primary: baseColors.red_500,
-        secondary: baseColors.red_50,
+        primary: baseColors.red_600,
+        secondary: baseColors.red_600,
       },
     },
     text: {
@@ -405,20 +405,20 @@ const themes: Themes = {
     },
     status: {
       valid: {
-        primary: baseColors.green_400,
-        secondary: baseColors.green_700,
+        primary: baseColors.green_300,
+        secondary: baseColors.green_300,
       },
       info: {
-        primary: baseColors.blue_500,
-        secondary: baseColors.blue_800,
+        primary: baseColors.cyan_200,
+        secondary: baseColors.cyan_200,
       },
       warning: {
         primary: baseColors.yellow_200,
-        secondary: baseColors.green_900,
+        secondary: baseColors.yellow_200,
       },
       error: {
-        primary: baseColors.red_500,
-        secondary: baseColors.red_900,
+        primary: baseColors.red_600,
+        secondary: baseColors.red_600,
       },
     },
     text: {


### PR DESCRIPTION
Reverts some of the color change for AtB in PR https://github.com/AtB-AS/design-system/pull/171

This will use the old color for both `primary` and `secondary`, so that at least we can update the usage in the app without any visual change.

A learning from this color system update, is that when we introduce new system, change the system with existing values first, and then update the values later. 📖 

PR on app : https://github.com/AtB-AS/mittatb-app/pull/4548