### PR TITLE
feat: Add geofencingZones

### DIFF
--- a/packages/theme/src/theme.ts
+++ b/packages/theme/src/theme.ts
@@ -58,7 +58,7 @@ export type GeofencingZoneStyle = {
   layerIndexWeight: number;
 };
 
-export type GeofencingZonesStyle = {
+export type GeofencingZoneStyles = {
   [GZKey in GeofencingZoneKeys]: GeofencingZoneStyle;
 };
 
@@ -128,7 +128,7 @@ export interface Theme {
   icon: {
     size: typeof iconSizes;
   };
-  geofencingZones: GeofencingZonesStyle;
+  geofencingZones: GeofencingZoneStyles;
 }
 
 export type Statuses = keyof Theme['status'];

--- a/packages/theme/src/theme.ts
+++ b/packages/theme/src/theme.ts
@@ -51,15 +51,15 @@ export enum GeofencingZoneCodes {
 
 export type GeofencingZoneKeys = keyof typeof GeofencingZoneCodes;
 
-export type GeofencingZonePaintProps = {
+export type GeofencingZoneStyle = {
   color: ContrastColor;
   fillOpacity: number;
   strokeOpacity: number;
   layerIndexWeight: number;
 };
 
-export type GeofencingZonesPaintProps = {
-  [GZKey in GeofencingZoneKeys]: GeofencingZonePaintProps;
+export type GeofencingZonesStyle = {
+  [GZKey in GeofencingZoneKeys]: GeofencingZoneStyle;
 };
 
 export interface Theme {
@@ -128,7 +128,7 @@ export interface Theme {
   icon: {
     size: typeof iconSizes;
   };
-  geofencingZones: GeofencingZonesPaintProps;
+  geofencingZones: GeofencingZonesStyle;
 }
 
 export type Statuses = keyof Theme['status'];

--- a/packages/theme/src/theme.ts
+++ b/packages/theme/src/theme.ts
@@ -41,11 +41,12 @@ export type InteractiveColor = {
   destructive: ContrastColor;
 };
 
+// The colors can be changed, but should follow standard practice as commented:
 export enum GeofencingZoneCodes {
-  Allowed = 'Allowed',
-  Slow = 'Slow',
-  NoParking = 'NoParking',
-  NoEntry = 'NoEntry',
+  Allowed = 'Allowed', // blue
+  Slow = 'Slow', // yellow
+  NoParking = 'NoParking', // red
+  NoEntry = 'NoEntry', // dark/black
 }
 
 export type GeofencingZoneKeys = keyof typeof GeofencingZoneCodes;

--- a/packages/theme/src/theme.ts
+++ b/packages/theme/src/theme.ts
@@ -41,6 +41,26 @@ export type InteractiveColor = {
   destructive: ContrastColor;
 };
 
+export enum GeofencingZoneCodes {
+  Allowed = 'Allowed',
+  Slow = 'Slow',
+  NoParking = 'NoParking',
+  NoEntry = 'NoEntry',
+}
+
+export type GeofencingZoneKeys = keyof typeof GeofencingZoneCodes;
+
+export type GeofencingZonePaintProps = {
+  color: ContrastColor;
+  fillOpacity: number;
+  strokeOpacity: number;
+  layerIndexWeight: number;
+};
+
+export type GeofencingZonesPaintProps = {
+  [GZKey in GeofencingZoneKeys]: GeofencingZonePaintProps;
+};
+
 export interface Theme {
   spacings: typeof spacings;
 
@@ -107,6 +127,7 @@ export interface Theme {
   icon: {
     size: typeof iconSizes;
   };
+  geofencingZones: GeofencingZonesPaintProps;
 }
 
 export type Statuses = keyof Theme['status'];

--- a/packages/theme/src/themes/atb-theme/theme.ts
+++ b/packages/theme/src/themes/atb-theme/theme.ts
@@ -105,7 +105,7 @@ export const baseColors = {
   yellow_900: contrastColor('#460200', 'light'),
 
   // red
-  red_50: contrastColor('#F4E1E7','dark'),
+  red_50: contrastColor('#F4E1E7', 'dark'),
   red_100: contrastColor('#EED2DB', 'dark'),
   red_200: contrastColor('#E4B8C6', 'dark'),
   red_300: contrastColor('#D691A7', 'dark'),
@@ -289,6 +289,32 @@ const themes: Themes = {
     icon: {
       size: iconSizes,
     },
+    geofencingZones: {
+      Allowed: {
+        color: baseColors.blue_500,
+        fillOpacity: 0.075,
+        strokeOpacity: 0.5,
+        layerIndexWeight: 1,
+      },
+      Slow: {
+        color: baseColors.yellow_100,
+        fillOpacity: 0.6,
+        strokeOpacity: 0.8,
+        layerIndexWeight: 2,
+      },
+      NoParking: {
+        color: baseColors.red_400,
+        fillOpacity: 0.5,
+        strokeOpacity: 0.7,
+        layerIndexWeight: 3,
+      },
+      NoEntry: {
+        color: baseColors.red_900,
+        fillOpacity: 0.55,
+        strokeOpacity: 0.75,
+        layerIndexWeight: 5,
+      },
+    },
   },
   dark: {
     spacings: spacings,
@@ -437,6 +463,32 @@ const themes: Themes = {
     },
     icon: {
       size: iconSizes,
+    },
+    geofencingZones: {
+      Allowed: {
+        color: baseColors.blue_500,
+        fillOpacity: 0.075,
+        strokeOpacity: 0.5,
+        layerIndexWeight: 1,
+      },
+      Slow: {
+        color: baseColors.yellow_100,
+        fillOpacity: 0.6,
+        strokeOpacity: 0.8,
+        layerIndexWeight: 2,
+      },
+      NoParking: {
+        color: baseColors.red_400,
+        fillOpacity: 0.5,
+        strokeOpacity: 0.7,
+        layerIndexWeight: 3,
+      },
+      NoEntry: {
+        color: baseColors.red_900,
+        fillOpacity: 0.55,
+        strokeOpacity: 0.75,
+        layerIndexWeight: 5,
+      },
     },
   },
 };

--- a/packages/theme/src/themes/fram-theme/theme.ts
+++ b/packages/theme/src/themes/fram-theme/theme.ts
@@ -16,6 +16,20 @@ const contrastColor = (
   };
 };
 
+// Currently exactly the same as in the AtB theme.
+// The colors can be changed, but should follow standard practice:
+// no entry - dark/black
+// no parking - red
+// slow zone - yellow
+// allowed - blue
+
+export const geofencingZoneBaseColors = {
+  blue_500: contrastColor('#007C92', 'light'),
+  yellow_100: contrastColor('#F0E973', 'dark'),
+  red_400: contrastColor('#C76B89', 'dark'),
+  red_900: contrastColor('#380616', 'light'),
+};
+
 const themes: Themes = {
   light: {
     spacings: spacings,
@@ -164,6 +178,32 @@ const themes: Themes = {
     icon: {
       size: iconSizes,
     },
+    geofencingZones: {
+      Allowed: {
+        color: geofencingZoneBaseColors.blue_500,
+        fillOpacity: 0.075,
+        strokeOpacity: 0.5,
+        layerIndexWeight: 1,
+      },
+      Slow: {
+        color: geofencingZoneBaseColors.yellow_100,
+        fillOpacity: 0.6,
+        strokeOpacity: 0.8,
+        layerIndexWeight: 2,
+      },
+      NoParking: {
+        color: geofencingZoneBaseColors.red_400,
+        fillOpacity: 0.5,
+        strokeOpacity: 0.7,
+        layerIndexWeight: 3,
+      },
+      NoEntry: {
+        color: geofencingZoneBaseColors.red_900,
+        fillOpacity: 0.55,
+        strokeOpacity: 0.75,
+        layerIndexWeight: 5,
+      },
+    },
   },
   dark: {
     spacings: spacings,
@@ -311,6 +351,32 @@ const themes: Themes = {
     },
     icon: {
       size: iconSizes,
+    },
+    geofencingZones: {
+      Allowed: {
+        color: geofencingZoneBaseColors.blue_500,
+        fillOpacity: 0.075,
+        strokeOpacity: 0.5,
+        layerIndexWeight: 1,
+      },
+      Slow: {
+        color: geofencingZoneBaseColors.yellow_100,
+        fillOpacity: 0.6,
+        strokeOpacity: 0.8,
+        layerIndexWeight: 2,
+      },
+      NoParking: {
+        color: geofencingZoneBaseColors.red_400,
+        fillOpacity: 0.5,
+        strokeOpacity: 0.7,
+        layerIndexWeight: 3,
+      },
+      NoEntry: {
+        color: geofencingZoneBaseColors.red_900,
+        fillOpacity: 0.55,
+        strokeOpacity: 0.75,
+        layerIndexWeight: 5,
+      },
     },
   },
 };

--- a/packages/theme/src/themes/fram-theme/theme.ts
+++ b/packages/theme/src/themes/fram-theme/theme.ts
@@ -16,13 +16,6 @@ const contrastColor = (
   };
 };
 
-// Currently exactly the same as in the AtB theme.
-// The colors can be changed, but should follow standard practice:
-// no entry - dark/black
-// no parking - red
-// slow zone - yellow
-// allowed - blue
-
 export const geofencingZoneBaseColors = {
   blue_500: contrastColor('#007C92', 'light'),
   yellow_100: contrastColor('#F0E973', 'dark'),

--- a/packages/theme/src/themes/innlandet-theme/theme.ts
+++ b/packages/theme/src/themes/innlandet-theme/theme.ts
@@ -286,6 +286,32 @@ const themes: Themes = {
     icon: {
       size: iconSizes,
     },
+    geofencingZones: {
+      Allowed: {
+        color: baseColors.blue_500,
+        fillOpacity: 0.075,
+        strokeOpacity: 0.5,
+        layerIndexWeight: 1,
+      },
+      Slow: {
+        color: baseColors.yellow_100,
+        fillOpacity: 0.6,
+        strokeOpacity: 0.8,
+        layerIndexWeight: 2,
+      },
+      NoParking: {
+        color: baseColors.red_400,
+        fillOpacity: 0.5,
+        strokeOpacity: 0.7,
+        layerIndexWeight: 3,
+      },
+      NoEntry: {
+        color: baseColors.red_900,
+        fillOpacity: 0.55,
+        strokeOpacity: 0.75,
+        layerIndexWeight: 5,
+      },
+    },
   },
   dark: {
     spacings: spacings,
@@ -434,6 +460,32 @@ const themes: Themes = {
     },
     icon: {
       size: iconSizes,
+    },
+    geofencingZones: {
+      Allowed: {
+        color: baseColors.blue_500,
+        fillOpacity: 0.075,
+        strokeOpacity: 0.5,
+        layerIndexWeight: 1,
+      },
+      Slow: {
+        color: baseColors.yellow_100,
+        fillOpacity: 0.6,
+        strokeOpacity: 0.8,
+        layerIndexWeight: 2,
+      },
+      NoParking: {
+        color: baseColors.red_400,
+        fillOpacity: 0.5,
+        strokeOpacity: 0.7,
+        layerIndexWeight: 3,
+      },
+      NoEntry: {
+        color: baseColors.red_900,
+        fillOpacity: 0.55,
+        strokeOpacity: 0.75,
+        layerIndexWeight: 5,
+      },
     },
   },
 };

--- a/packages/theme/src/themes/nfk-theme/theme.ts
+++ b/packages/theme/src/themes/nfk-theme/theme.ts
@@ -21,6 +21,20 @@ const contrastColor = (
   };
 };
 
+// Currently exactly the same as in the AtB theme.
+// The colors can be changed, but should follow standard practice:
+// no entry - dark/black
+// no parking - red
+// slow zone - yellow
+// allowed - blue
+
+export const geofencingZoneBaseColors = {
+  blue_500: contrastColor('#007C92', 'light'),
+  yellow_100: contrastColor('#F0E973', 'dark'),
+  red_400: contrastColor('#C76B89', 'dark'),
+  red_900: contrastColor('#380616', 'light'),
+};
+
 const themes: Themes = {
   light: {
     spacings: spacings,
@@ -169,6 +183,32 @@ const themes: Themes = {
     icon: {
       size: iconSizes,
     },
+    geofencingZones: {
+      Allowed: {
+        color: geofencingZoneBaseColors.blue_500,
+        fillOpacity: 0.075,
+        strokeOpacity: 0.5,
+        layerIndexWeight: 1,
+      },
+      Slow: {
+        color: geofencingZoneBaseColors.yellow_100,
+        fillOpacity: 0.6,
+        strokeOpacity: 0.8,
+        layerIndexWeight: 2,
+      },
+      NoParking: {
+        color: geofencingZoneBaseColors.red_400,
+        fillOpacity: 0.5,
+        strokeOpacity: 0.7,
+        layerIndexWeight: 3,
+      },
+      NoEntry: {
+        color: geofencingZoneBaseColors.red_900,
+        fillOpacity: 0.55,
+        strokeOpacity: 0.75,
+        layerIndexWeight: 5,
+      },
+    },
   },
   dark: {
     spacings: spacings,
@@ -316,6 +356,32 @@ const themes: Themes = {
     },
     icon: {
       size: iconSizes,
+    },
+    geofencingZones: {
+      Allowed: {
+        color: geofencingZoneBaseColors.blue_500,
+        fillOpacity: 0.075,
+        strokeOpacity: 0.5,
+        layerIndexWeight: 1,
+      },
+      Slow: {
+        color: geofencingZoneBaseColors.yellow_100,
+        fillOpacity: 0.6,
+        strokeOpacity: 0.8,
+        layerIndexWeight: 2,
+      },
+      NoParking: {
+        color: geofencingZoneBaseColors.red_400,
+        fillOpacity: 0.5,
+        strokeOpacity: 0.7,
+        layerIndexWeight: 3,
+      },
+      NoEntry: {
+        color: geofencingZoneBaseColors.red_900,
+        fillOpacity: 0.55,
+        strokeOpacity: 0.75,
+        layerIndexWeight: 5,
+      },
     },
   },
 };

--- a/packages/theme/src/themes/nfk-theme/theme.ts
+++ b/packages/theme/src/themes/nfk-theme/theme.ts
@@ -21,13 +21,6 @@ const contrastColor = (
   };
 };
 
-// Currently exactly the same as in the AtB theme.
-// The colors can be changed, but should follow standard practice:
-// no entry - dark/black
-// no parking - red
-// slow zone - yellow
-// allowed - blue
-
 export const geofencingZoneBaseColors = {
   blue_500: contrastColor('#007C92', 'light'),
   yellow_100: contrastColor('#F0E973', 'dark'),

--- a/packages/theme/src/themes/troms-theme/theme.ts
+++ b/packages/theme/src/themes/troms-theme/theme.ts
@@ -293,6 +293,32 @@ const themes: Themes = {
     icon: {
       size: iconSizes,
     },
+    geofencingZones: {
+      Allowed: {
+        color: baseColors.blue_500,
+        fillOpacity: 0.075,
+        strokeOpacity: 0.5,
+        layerIndexWeight: 1,
+      },
+      Slow: {
+        color: baseColors.yellow_100,
+        fillOpacity: 0.6,
+        strokeOpacity: 0.8,
+        layerIndexWeight: 2,
+      },
+      NoParking: {
+        color: baseColors.red_400,
+        fillOpacity: 0.5,
+        strokeOpacity: 0.7,
+        layerIndexWeight: 3,
+      },
+      NoEntry: {
+        color: baseColors.red_900,
+        fillOpacity: 0.55,
+        strokeOpacity: 0.75,
+        layerIndexWeight: 5,
+      },
+    },
   },
   dark: {
     spacings: spacings,
@@ -441,6 +467,32 @@ const themes: Themes = {
     },
     icon: {
       size: iconSizes,
+    },
+    geofencingZones: {
+      Allowed: {
+        color: baseColors.blue_500,
+        fillOpacity: 0.075,
+        strokeOpacity: 0.5,
+        layerIndexWeight: 1,
+      },
+      Slow: {
+        color: baseColors.yellow_100,
+        fillOpacity: 0.6,
+        strokeOpacity: 0.8,
+        layerIndexWeight: 2,
+      },
+      NoParking: {
+        color: baseColors.red_400,
+        fillOpacity: 0.5,
+        strokeOpacity: 0.7,
+        layerIndexWeight: 3,
+      },
+      NoEntry: {
+        color: baseColors.red_900,
+        fillOpacity: 0.55,
+        strokeOpacity: 0.75,
+        layerIndexWeight: 5,
+      },
     },
   },
 };


### PR DESCRIPTION
In order to show color-encoded geofencingZones in the map, `geofencingZones` is added to the design system.

<table>
  <tr>
    <td><img width="200" src="https://github.com/AtB-AS/design-system/assets/134292729/81365aa5-5961-440c-ad91-7014ee29067f" /></td>
    <td><img width="200" src="https://github.com/AtB-AS/design-system/assets/134292729/fda7f76a-2325-4e0d-8932-2b2d6745ae74" /></td>
     <td><img width="200" src="https://github.com/AtB-AS/design-system/assets/134292729/9e3592d2-9fa9-468e-b936-6db96552745c" /></td>
      <td><img width="200" src="https://github.com/AtB-AS/design-system/assets/134292729/6692a93f-ffa1-4260-ba22-5ab2239c8413" /></td>
  </tr>
  <tr>
    <td>Allowed</td>
    <td>Slow</td>
    <td>No Parking</td>
    <td>No Entry</td>
  </tr>
</table>

Resolves https://github.com/AtB-AS/kundevendt/issues/17614