### PR TITLE
fix: change interactive outline colors

### DIFF
--- a/packages/theme/src/themes/fram-theme/theme.css
+++ b/packages/theme/src/themes/fram-theme/theme.css
@@ -59,8 +59,8 @@
   --interactive-interactive_0-active-text: #000000;
   --interactive-interactive_0-disabled-background: rgba(0, 86, 134, 0.2);
   --interactive-interactive_0-disabled-text: #FFFFFF;
-  --interactive-interactive_0-outline-background: #0D6569;
-  --interactive-interactive_0-outline-text: #FFFFFF;
+  --interactive-interactive_0-outline-background: #3395C4;
+  --interactive-interactive_0-outline-text: #000000;
   --interactive-interactive_0-destructive-background: #B6161C;
   --interactive-interactive_0-destructive-text: #FFFFFF;
   --interactive-interactive_1-default-background: #005686;
@@ -71,8 +71,8 @@
   --interactive-interactive_1-active-text: #FFFFFF;
   --interactive-interactive_1-disabled-background: rgba(0, 86, 134, 0.2);
   --interactive-interactive_1-disabled-text: #FFFFFF;
-  --interactive-interactive_1-outline-background: #0D6569;
-  --interactive-interactive_1-outline-text: #FFFFFF;
+  --interactive-interactive_1-outline-background: #3395C4;
+  --interactive-interactive_1-outline-text: #000000;
   --interactive-interactive_1-destructive-background: #B6161C;
   --interactive-interactive_1-destructive-text: #FFFFFF;
   --interactive-interactive_2-default-background: #FFFFFF;
@@ -83,8 +83,8 @@
   --interactive-interactive_2-active-text: #000000;
   --interactive-interactive_2-disabled-background: rgba(255, 255, 255, 0.2);
   --interactive-interactive_2-disabled-text: #000000;
-  --interactive-interactive_2-outline-background: #0D6569;
-  --interactive-interactive_2-outline-text: #FFFFFF;
+  --interactive-interactive_2-outline-background: #3395C4;
+  --interactive-interactive_2-outline-text: #000000;
   --interactive-interactive_2-destructive-background: #B6161C;
   --interactive-interactive_2-destructive-text: #FFFFFF;
   --interactive-interactive_3-default-background: #82B962;
@@ -95,8 +95,8 @@
   --interactive-interactive_3-active-text: #000000;
   --interactive-interactive_3-disabled-background: rgba(130, 185, 98, 0.2);
   --interactive-interactive_3-disabled-text: #000000;
-  --interactive-interactive_3-outline-background: #0D6569;
-  --interactive-interactive_3-outline-text: #FFFFFF;
+  --interactive-interactive_3-outline-background: #3395C4;
+  --interactive-interactive_3-outline-text: #000000;
   --interactive-interactive_3-destructive-background: #B6161C;
   --interactive-interactive_3-destructive-text: #FFFFFF;
   --interactive-interactive_destructive-default-background: #E31B22;
@@ -107,8 +107,8 @@
   --interactive-interactive_destructive-active-text: #000000;
   --interactive-interactive_destructive-disabled-background: rgba(227, 27, 34, 0.2);
   --interactive-interactive_destructive-disabled-text: #FFFFFF;
-  --interactive-interactive_destructive-outline-background: #0D6569;
-  --interactive-interactive_destructive-outline-text: #FFFFFF;
+  --interactive-interactive_destructive-outline-background: #3395C4;
+  --interactive-interactive_destructive-outline-text: #000000;
   --interactive-interactive_destructive-destructive-background: #B6161C;
   --interactive-interactive_destructive-destructive-text: #FFFFFF;
 
@@ -222,7 +222,7 @@
   --interactive-interactive_0-active-text: #000000;
   --interactive-interactive_0-disabled-background: rgba(0, 122, 181, 0.2);
   --interactive-interactive_0-disabled-text: #FFFFFF;
-  --interactive-interactive_0-outline-background: #CDE9E3;
+  --interactive-interactive_0-outline-background: #F0E991;
   --interactive-interactive_0-outline-text: #000000;
   --interactive-interactive_0-destructive-background: #EE777B;
   --interactive-interactive_0-destructive-text: #000000;
@@ -234,7 +234,7 @@
   --interactive-interactive_1-active-text: #FFFFFF;
   --interactive-interactive_1-disabled-background: rgba(0, 122, 181, 0.2);
   --interactive-interactive_1-disabled-text: #FFFFFF;
-  --interactive-interactive_1-outline-background: #CDE9E3;
+  --interactive-interactive_1-outline-background: #F0E991;
   --interactive-interactive_1-outline-text: #000000;
   --interactive-interactive_1-destructive-background: #EE777B;
   --interactive-interactive_1-destructive-text: #000000;
@@ -246,7 +246,7 @@
   --interactive-interactive_2-active-text: #FFFFFF;
   --interactive-interactive_2-disabled-background: rgba(1, 22, 34, 0.2);
   --interactive-interactive_2-disabled-text: #FFFFFF;
-  --interactive-interactive_2-outline-background: #CDE9E3;
+  --interactive-interactive_2-outline-background: #F0E991;
   --interactive-interactive_2-outline-text: #000000;
   --interactive-interactive_2-destructive-background: #EE777B;
   --interactive-interactive_2-destructive-text: #000000;
@@ -258,7 +258,7 @@
   --interactive-interactive_3-active-text: #FFFFFF;
   --interactive-interactive_3-disabled-background: rgba(40, 67, 32, 0.2);
   --interactive-interactive_3-disabled-text: #FFFFFF;
-  --interactive-interactive_3-outline-background: #CDE9E3;
+  --interactive-interactive_3-outline-background: #F0E991;
   --interactive-interactive_3-outline-text: #000000;
   --interactive-interactive_3-destructive-background: #EE777B;
   --interactive-interactive_3-destructive-text: #000000;
@@ -270,7 +270,7 @@
   --interactive-interactive_destructive-active-text: #000000;
   --interactive-interactive_destructive-disabled-background: rgba(227, 27, 34, 0.2);
   --interactive-interactive_destructive-disabled-text: #FFFFFF;
-  --interactive-interactive_destructive-outline-background: #CDE9E3;
+  --interactive-interactive_destructive-outline-background: #F0E991;
   --interactive-interactive_destructive-outline-text: #000000;
   --interactive-interactive_destructive-destructive-background: #EE777B;
   --interactive-interactive_destructive-destructive-text: #000000;
@@ -385,7 +385,7 @@
   --interactive-interactive_0-active-text: #000000;
   --interactive-interactive_0-disabled-background: rgba(0, 122, 181, 0.2);
   --interactive-interactive_0-disabled-text: #FFFFFF;
-  --interactive-interactive_0-outline-background: #CDE9E3;
+  --interactive-interactive_0-outline-background: #F0E991;
   --interactive-interactive_0-outline-text: #000000;
   --interactive-interactive_0-destructive-background: #EE777B;
   --interactive-interactive_0-destructive-text: #000000;
@@ -397,7 +397,7 @@
   --interactive-interactive_1-active-text: #FFFFFF;
   --interactive-interactive_1-disabled-background: rgba(0, 122, 181, 0.2);
   --interactive-interactive_1-disabled-text: #FFFFFF;
-  --interactive-interactive_1-outline-background: #CDE9E3;
+  --interactive-interactive_1-outline-background: #F0E991;
   --interactive-interactive_1-outline-text: #000000;
   --interactive-interactive_1-destructive-background: #EE777B;
   --interactive-interactive_1-destructive-text: #000000;
@@ -409,7 +409,7 @@
   --interactive-interactive_2-active-text: #FFFFFF;
   --interactive-interactive_2-disabled-background: rgba(1, 22, 34, 0.2);
   --interactive-interactive_2-disabled-text: #FFFFFF;
-  --interactive-interactive_2-outline-background: #CDE9E3;
+  --interactive-interactive_2-outline-background: #F0E991;
   --interactive-interactive_2-outline-text: #000000;
   --interactive-interactive_2-destructive-background: #EE777B;
   --interactive-interactive_2-destructive-text: #000000;
@@ -421,7 +421,7 @@
   --interactive-interactive_3-active-text: #FFFFFF;
   --interactive-interactive_3-disabled-background: rgba(40, 67, 32, 0.2);
   --interactive-interactive_3-disabled-text: #FFFFFF;
-  --interactive-interactive_3-outline-background: #CDE9E3;
+  --interactive-interactive_3-outline-background: #F0E991;
   --interactive-interactive_3-outline-text: #000000;
   --interactive-interactive_3-destructive-background: #EE777B;
   --interactive-interactive_3-destructive-text: #000000;
@@ -433,7 +433,7 @@
   --interactive-interactive_destructive-active-text: #000000;
   --interactive-interactive_destructive-disabled-background: rgba(227, 27, 34, 0.2);
   --interactive-interactive_destructive-disabled-text: #FFFFFF;
-  --interactive-interactive_destructive-outline-background: #CDE9E3;
+  --interactive-interactive_destructive-outline-background: #F0E991;
   --interactive-interactive_destructive-outline-text: #000000;
   --interactive-interactive_destructive-destructive-background: #EE777B;
   --interactive-interactive_destructive-destructive-text: #000000;

--- a/packages/theme/src/themes/fram-theme/theme.module.css
+++ b/packages/theme/src/themes/fram-theme/theme.module.css
@@ -59,8 +59,8 @@
   --interactive-interactive_0-active-text: #000000;
   --interactive-interactive_0-disabled-background: rgba(0, 86, 134, 0.2);
   --interactive-interactive_0-disabled-text: #FFFFFF;
-  --interactive-interactive_0-outline-background: #0D6569;
-  --interactive-interactive_0-outline-text: #FFFFFF;
+  --interactive-interactive_0-outline-background: #3395C4;
+  --interactive-interactive_0-outline-text: #000000;
   --interactive-interactive_0-destructive-background: #B6161C;
   --interactive-interactive_0-destructive-text: #FFFFFF;
   --interactive-interactive_1-default-background: #005686;
@@ -71,8 +71,8 @@
   --interactive-interactive_1-active-text: #FFFFFF;
   --interactive-interactive_1-disabled-background: rgba(0, 86, 134, 0.2);
   --interactive-interactive_1-disabled-text: #FFFFFF;
-  --interactive-interactive_1-outline-background: #0D6569;
-  --interactive-interactive_1-outline-text: #FFFFFF;
+  --interactive-interactive_1-outline-background: #3395C4;
+  --interactive-interactive_1-outline-text: #000000;
   --interactive-interactive_1-destructive-background: #B6161C;
   --interactive-interactive_1-destructive-text: #FFFFFF;
   --interactive-interactive_2-default-background: #FFFFFF;
@@ -83,8 +83,8 @@
   --interactive-interactive_2-active-text: #000000;
   --interactive-interactive_2-disabled-background: rgba(255, 255, 255, 0.2);
   --interactive-interactive_2-disabled-text: #000000;
-  --interactive-interactive_2-outline-background: #0D6569;
-  --interactive-interactive_2-outline-text: #FFFFFF;
+  --interactive-interactive_2-outline-background: #3395C4;
+  --interactive-interactive_2-outline-text: #000000;
   --interactive-interactive_2-destructive-background: #B6161C;
   --interactive-interactive_2-destructive-text: #FFFFFF;
   --interactive-interactive_3-default-background: #82B962;
@@ -95,8 +95,8 @@
   --interactive-interactive_3-active-text: #000000;
   --interactive-interactive_3-disabled-background: rgba(130, 185, 98, 0.2);
   --interactive-interactive_3-disabled-text: #000000;
-  --interactive-interactive_3-outline-background: #0D6569;
-  --interactive-interactive_3-outline-text: #FFFFFF;
+  --interactive-interactive_3-outline-background: #3395C4;
+  --interactive-interactive_3-outline-text: #000000;
   --interactive-interactive_3-destructive-background: #B6161C;
   --interactive-interactive_3-destructive-text: #FFFFFF;
   --interactive-interactive_destructive-default-background: #E31B22;
@@ -107,8 +107,8 @@
   --interactive-interactive_destructive-active-text: #000000;
   --interactive-interactive_destructive-disabled-background: rgba(227, 27, 34, 0.2);
   --interactive-interactive_destructive-disabled-text: #FFFFFF;
-  --interactive-interactive_destructive-outline-background: #0D6569;
-  --interactive-interactive_destructive-outline-text: #FFFFFF;
+  --interactive-interactive_destructive-outline-background: #3395C4;
+  --interactive-interactive_destructive-outline-text: #000000;
   --interactive-interactive_destructive-destructive-background: #B6161C;
   --interactive-interactive_destructive-destructive-text: #FFFFFF;
 
@@ -222,7 +222,7 @@
   --interactive-interactive_0-active-text: #000000;
   --interactive-interactive_0-disabled-background: rgba(0, 122, 181, 0.2);
   --interactive-interactive_0-disabled-text: #FFFFFF;
-  --interactive-interactive_0-outline-background: #CDE9E3;
+  --interactive-interactive_0-outline-background: #F0E991;
   --interactive-interactive_0-outline-text: #000000;
   --interactive-interactive_0-destructive-background: #EE777B;
   --interactive-interactive_0-destructive-text: #000000;
@@ -234,7 +234,7 @@
   --interactive-interactive_1-active-text: #FFFFFF;
   --interactive-interactive_1-disabled-background: rgba(0, 122, 181, 0.2);
   --interactive-interactive_1-disabled-text: #FFFFFF;
-  --interactive-interactive_1-outline-background: #CDE9E3;
+  --interactive-interactive_1-outline-background: #F0E991;
   --interactive-interactive_1-outline-text: #000000;
   --interactive-interactive_1-destructive-background: #EE777B;
   --interactive-interactive_1-destructive-text: #000000;
@@ -246,7 +246,7 @@
   --interactive-interactive_2-active-text: #FFFFFF;
   --interactive-interactive_2-disabled-background: rgba(1, 22, 34, 0.2);
   --interactive-interactive_2-disabled-text: #FFFFFF;
-  --interactive-interactive_2-outline-background: #CDE9E3;
+  --interactive-interactive_2-outline-background: #F0E991;
   --interactive-interactive_2-outline-text: #000000;
   --interactive-interactive_2-destructive-background: #EE777B;
   --interactive-interactive_2-destructive-text: #000000;
@@ -258,7 +258,7 @@
   --interactive-interactive_3-active-text: #FFFFFF;
   --interactive-interactive_3-disabled-background: rgba(40, 67, 32, 0.2);
   --interactive-interactive_3-disabled-text: #FFFFFF;
-  --interactive-interactive_3-outline-background: #CDE9E3;
+  --interactive-interactive_3-outline-background: #F0E991;
   --interactive-interactive_3-outline-text: #000000;
   --interactive-interactive_3-destructive-background: #EE777B;
   --interactive-interactive_3-destructive-text: #000000;
@@ -270,7 +270,7 @@
   --interactive-interactive_destructive-active-text: #000000;
   --interactive-interactive_destructive-disabled-background: rgba(227, 27, 34, 0.2);
   --interactive-interactive_destructive-disabled-text: #FFFFFF;
-  --interactive-interactive_destructive-outline-background: #CDE9E3;
+  --interactive-interactive_destructive-outline-background: #F0E991;
   --interactive-interactive_destructive-outline-text: #000000;
   --interactive-interactive_destructive-destructive-background: #EE777B;
   --interactive-interactive_destructive-destructive-text: #000000;
@@ -385,7 +385,7 @@
   --interactive-interactive_0-active-text: #000000;
   --interactive-interactive_0-disabled-background: rgba(0, 122, 181, 0.2);
   --interactive-interactive_0-disabled-text: #FFFFFF;
-  --interactive-interactive_0-outline-background: #CDE9E3;
+  --interactive-interactive_0-outline-background: #F0E991;
   --interactive-interactive_0-outline-text: #000000;
   --interactive-interactive_0-destructive-background: #EE777B;
   --interactive-interactive_0-destructive-text: #000000;
@@ -397,7 +397,7 @@
   --interactive-interactive_1-active-text: #FFFFFF;
   --interactive-interactive_1-disabled-background: rgba(0, 122, 181, 0.2);
   --interactive-interactive_1-disabled-text: #FFFFFF;
-  --interactive-interactive_1-outline-background: #CDE9E3;
+  --interactive-interactive_1-outline-background: #F0E991;
   --interactive-interactive_1-outline-text: #000000;
   --interactive-interactive_1-destructive-background: #EE777B;
   --interactive-interactive_1-destructive-text: #000000;
@@ -409,7 +409,7 @@
   --interactive-interactive_2-active-text: #FFFFFF;
   --interactive-interactive_2-disabled-background: rgba(1, 22, 34, 0.2);
   --interactive-interactive_2-disabled-text: #FFFFFF;
-  --interactive-interactive_2-outline-background: #CDE9E3;
+  --interactive-interactive_2-outline-background: #F0E991;
   --interactive-interactive_2-outline-text: #000000;
   --interactive-interactive_2-destructive-background: #EE777B;
   --interactive-interactive_2-destructive-text: #000000;
@@ -421,7 +421,7 @@
   --interactive-interactive_3-active-text: #FFFFFF;
   --interactive-interactive_3-disabled-background: rgba(40, 67, 32, 0.2);
   --interactive-interactive_3-disabled-text: #FFFFFF;
-  --interactive-interactive_3-outline-background: #CDE9E3;
+  --interactive-interactive_3-outline-background: #F0E991;
   --interactive-interactive_3-outline-text: #000000;
   --interactive-interactive_3-destructive-background: #EE777B;
   --interactive-interactive_3-destructive-text: #000000;
@@ -433,7 +433,7 @@
   --interactive-interactive_destructive-active-text: #000000;
   --interactive-interactive_destructive-disabled-background: rgba(227, 27, 34, 0.2);
   --interactive-interactive_destructive-disabled-text: #FFFFFF;
-  --interactive-interactive_destructive-outline-background: #CDE9E3;
+  --interactive-interactive_destructive-outline-background: #F0E991;
   --interactive-interactive_destructive-outline-text: #000000;
   --interactive-interactive_destructive-destructive-background: #EE777B;
   --interactive-interactive_destructive-destructive-text: #000000;

--- a/packages/theme/src/themes/fram-theme/theme.ts
+++ b/packages/theme/src/themes/fram-theme/theme.ts
@@ -275,7 +275,7 @@ const themes: Themes = {
         hover: baseColors.blue_dark_700,
         active: baseColors.blue_dark_300,
         disabled: contrastColorWithAlpha(baseColors.blue_dark_600, 0.20),
-        outline: baseColors.marine_dark_600,
+        outline: baseColors.blue_logo_400,
         destructive: baseColors.red_600,
       },
       interactive_1: {
@@ -283,7 +283,7 @@ const themes: Themes = {
         hover: baseColors.blue_dark_700,
         active: baseColors.blue_dark_900,
         disabled: contrastColorWithAlpha(baseColors.blue_dark_600, 0.20),
-        outline: baseColors.marine_dark_600,
+        outline: baseColors.blue_logo_400,
         destructive: baseColors.red_600,
       },
       interactive_2: {
@@ -291,7 +291,7 @@ const themes: Themes = {
         hover: baseColors.blue_dark_100,
         active: baseColors.blue_dark_200,
         disabled: contrastColorWithAlpha(baseColors.gray_0, 0.20),
-        outline: baseColors.marine_dark_600,
+        outline: baseColors.blue_logo_400,
         destructive: baseColors.red_600,
       },
       interactive_3: {
@@ -299,7 +299,7 @@ const themes: Themes = {
         hover: baseColors.green_light_400,
         active: baseColors.green_light_200,
         disabled: contrastColorWithAlpha(baseColors.green_light_300, 0.20),
-        outline: baseColors.marine_dark_600,
+        outline: baseColors.blue_logo_400,
         destructive: baseColors.red_600,
       },
       interactive_destructive: {
@@ -307,7 +307,7 @@ const themes: Themes = {
         hover: baseColors.red_600,
         active: baseColors.red_200,
         disabled: contrastColorWithAlpha(baseColors.red_500, 0.20),
-        outline: baseColors.marine_dark_600,
+        outline: baseColors.blue_logo_400,
         destructive: baseColors.red_600,
       },
     },
@@ -449,7 +449,7 @@ const themes: Themes = {
         hover: baseColors.blue_logo_600,
         active: baseColors.blue_logo_200,
         disabled: contrastColorWithAlpha(baseColors.blue_logo_500, 0.20),
-        outline: baseColors.marine_light_200,
+        outline: baseColors.yellow_logo_200,
         destructive: baseColors.red_300,
       },
       interactive_1: {
@@ -457,7 +457,7 @@ const themes: Themes = {
         hover: baseColors.blue_logo_600,
         active: baseColors.blue_logo_900,
         disabled: contrastColorWithAlpha(baseColors.blue_logo_500, 0.20),
-        outline: baseColors.marine_light_200,
+        outline: baseColors.yellow_logo_200,
         destructive: baseColors.red_300,
       },
       interactive_2: {
@@ -465,7 +465,7 @@ const themes: Themes = {
         hover: baseColors.blue_dark_800,
         active: baseColors.blue_dark_700,
         disabled: contrastColorWithAlpha(baseColors.blue_dark_900, 0.20),
-        outline: baseColors.marine_light_200,
+        outline: baseColors.yellow_logo_200,
         destructive: baseColors.red_300,
       },
       interactive_3: {
@@ -473,7 +473,7 @@ const themes: Themes = {
         hover: baseColors.green_dark_800,
         active: baseColors.green_dark_600,
         disabled: contrastColorWithAlpha(baseColors.green_dark_700, 0.20),
-        outline: baseColors.marine_light_200,
+        outline: baseColors.yellow_logo_200,
         destructive: baseColors.red_300,
       },
       interactive_destructive: {
@@ -481,7 +481,7 @@ const themes: Themes = {
         hover: baseColors.red_600,
         active: baseColors.red_200,
         disabled: contrastColorWithAlpha(baseColors.red_500, 0.20),
-        outline: baseColors.marine_light_200,
+        outline: baseColors.yellow_logo_200,
         destructive: baseColors.red_300,
       },
     },


### PR DESCRIPTION
The interactive outline didn't work well for e.g. the active tab tint.