### PR TITLE
fix: generate css status colors

### DIFF
--- a/packages/theme/src/themes/atb-theme/theme.css
+++ b/packages/theme/src/themes/atb-theme/theme.css
@@ -160,6 +160,23 @@
   --transport-transport_other-primary-text: #FFFFFF;
   --transport-transport_other-secondary-background: #2B343A;
   --transport-transport_other-secondary-text: #FFFFFF;
+
+  --status-valid-primary-background: #A2AD00;
+  --status-valid-primary-text: #000000;
+  --status-valid-secondary-background: #A2AD00;
+  --status-valid-secondary-text: #000000;
+  --status-info-primary-background: #71D6E0;
+  --status-info-primary-text: #000000;
+  --status-info-secondary-background: #71D6E0;
+  --status-info-secondary-text: #000000;
+  --status-warning-primary-background: #E4D700;
+  --status-warning-primary-text: #000000;
+  --status-warning-secondary-background: #E4D700;
+  --status-warning-secondary-text: #000000;
+  --status-error-primary-background: #A51140;
+  --status-error-primary-text: #FFFFFF;
+  --status-error-secondary-background: #A51140;
+  --status-error-secondary-text: #FFFFFF;
 }
 
 
@@ -323,6 +340,23 @@
   --transport-transport_other-primary-text: #000000;
   --transport-transport_other-secondary-background: #8D9398;
   --transport-transport_other-secondary-text: #000000;
+
+  --status-valid-primary-background: #A2AD00;
+  --status-valid-primary-text: #000000;
+  --status-valid-secondary-background: #A2AD00;
+  --status-valid-secondary-text: #000000;
+  --status-info-primary-background: #71D6E0;
+  --status-info-primary-text: #000000;
+  --status-info-secondary-background: #71D6E0;
+  --status-info-secondary-text: #000000;
+  --status-warning-primary-background: #E4D700;
+  --status-warning-primary-text: #000000;
+  --status-warning-secondary-background: #E4D700;
+  --status-warning-secondary-text: #000000;
+  --status-error-primary-background: #A51140;
+  --status-error-primary-text: #FFFFFF;
+  --status-error-secondary-background: #A51140;
+  --status-error-secondary-text: #FFFFFF;
 }
 
 
@@ -486,6 +520,23 @@
   --transport-transport_other-primary-text: #000000;
   --transport-transport_other-secondary-background: #8D9398;
   --transport-transport_other-secondary-text: #000000;
+
+  --status-valid-primary-background: #A2AD00;
+  --status-valid-primary-text: #000000;
+  --status-valid-secondary-background: #A2AD00;
+  --status-valid-secondary-text: #000000;
+  --status-info-primary-background: #71D6E0;
+  --status-info-primary-text: #000000;
+  --status-info-secondary-background: #71D6E0;
+  --status-info-secondary-text: #000000;
+  --status-warning-primary-background: #E4D700;
+  --status-warning-primary-text: #000000;
+  --status-warning-secondary-background: #E4D700;
+  --status-warning-secondary-text: #000000;
+  --status-error-primary-background: #A51140;
+  --status-error-primary-text: #FFFFFF;
+  --status-error-secondary-background: #A51140;
+  --status-error-secondary-text: #FFFFFF;
 }
 }
 
@@ -716,4 +767,37 @@
 .interactive-interactive_destructive:disabled {
   background-color: var(--interactive-interactive_destructive-disabled-background);
   color: var(--interactive-interactive_destructive-disabled-text);
+}
+
+.status-valid-primary {
+  background-color: var(--status-valid-primary-background);
+  color: var(--status-valid-primary-text);
+}
+.status-valid-secondary {
+  background-color: var(--status-valid-secondary-background);
+  color: var(--status-valid-secondary-text);
+}
+.status-info-primary {
+  background-color: var(--status-info-primary-background);
+  color: var(--status-info-primary-text);
+}
+.status-info-secondary {
+  background-color: var(--status-info-secondary-background);
+  color: var(--status-info-secondary-text);
+}
+.status-warning-primary {
+  background-color: var(--status-warning-primary-background);
+  color: var(--status-warning-primary-text);
+}
+.status-warning-secondary {
+  background-color: var(--status-warning-secondary-background);
+  color: var(--status-warning-secondary-text);
+}
+.status-error-primary {
+  background-color: var(--status-error-primary-background);
+  color: var(--status-error-primary-text);
+}
+.status-error-secondary {
+  background-color: var(--status-error-secondary-background);
+  color: var(--status-error-secondary-text);
 }

--- a/packages/theme/src/themes/atb-theme/theme.module.css
+++ b/packages/theme/src/themes/atb-theme/theme.module.css
@@ -160,6 +160,23 @@
   --transport-transport_other-primary-text: #FFFFFF;
   --transport-transport_other-secondary-background: #2B343A;
   --transport-transport_other-secondary-text: #FFFFFF;
+
+  --status-valid-primary-background: #A2AD00;
+  --status-valid-primary-text: #000000;
+  --status-valid-secondary-background: #A2AD00;
+  --status-valid-secondary-text: #000000;
+  --status-info-primary-background: #71D6E0;
+  --status-info-primary-text: #000000;
+  --status-info-secondary-background: #71D6E0;
+  --status-info-secondary-text: #000000;
+  --status-warning-primary-background: #E4D700;
+  --status-warning-primary-text: #000000;
+  --status-warning-secondary-background: #E4D700;
+  --status-warning-secondary-text: #000000;
+  --status-error-primary-background: #A51140;
+  --status-error-primary-text: #FFFFFF;
+  --status-error-secondary-background: #A51140;
+  --status-error-secondary-text: #FFFFFF;
 }
 
 
@@ -323,6 +340,23 @@
   --transport-transport_other-primary-text: #000000;
   --transport-transport_other-secondary-background: #8D9398;
   --transport-transport_other-secondary-text: #000000;
+
+  --status-valid-primary-background: #A2AD00;
+  --status-valid-primary-text: #000000;
+  --status-valid-secondary-background: #A2AD00;
+  --status-valid-secondary-text: #000000;
+  --status-info-primary-background: #71D6E0;
+  --status-info-primary-text: #000000;
+  --status-info-secondary-background: #71D6E0;
+  --status-info-secondary-text: #000000;
+  --status-warning-primary-background: #E4D700;
+  --status-warning-primary-text: #000000;
+  --status-warning-secondary-background: #E4D700;
+  --status-warning-secondary-text: #000000;
+  --status-error-primary-background: #A51140;
+  --status-error-primary-text: #FFFFFF;
+  --status-error-secondary-background: #A51140;
+  --status-error-secondary-text: #FFFFFF;
 }
 
 
@@ -486,6 +520,23 @@
   --transport-transport_other-primary-text: #000000;
   --transport-transport_other-secondary-background: #8D9398;
   --transport-transport_other-secondary-text: #000000;
+
+  --status-valid-primary-background: #A2AD00;
+  --status-valid-primary-text: #000000;
+  --status-valid-secondary-background: #A2AD00;
+  --status-valid-secondary-text: #000000;
+  --status-info-primary-background: #71D6E0;
+  --status-info-primary-text: #000000;
+  --status-info-secondary-background: #71D6E0;
+  --status-info-secondary-text: #000000;
+  --status-warning-primary-background: #E4D700;
+  --status-warning-primary-text: #000000;
+  --status-warning-secondary-background: #E4D700;
+  --status-warning-secondary-text: #000000;
+  --status-error-primary-background: #A51140;
+  --status-error-primary-text: #FFFFFF;
+  --status-error-secondary-background: #A51140;
+  --status-error-secondary-text: #FFFFFF;
 }
 }
 
@@ -716,4 +767,37 @@
 .interactive-interactive_destructive:disabled {
   background-color: var(--interactive-interactive_destructive-disabled-background);
   color: var(--interactive-interactive_destructive-disabled-text);
+}
+
+.status-valid-primary {
+  background-color: var(--status-valid-primary-background);
+  color: var(--status-valid-primary-text);
+}
+.status-valid-secondary {
+  background-color: var(--status-valid-secondary-background);
+  color: var(--status-valid-secondary-text);
+}
+.status-info-primary {
+  background-color: var(--status-info-primary-background);
+  color: var(--status-info-primary-text);
+}
+.status-info-secondary {
+  background-color: var(--status-info-secondary-background);
+  color: var(--status-info-secondary-text);
+}
+.status-warning-primary {
+  background-color: var(--status-warning-primary-background);
+  color: var(--status-warning-primary-text);
+}
+.status-warning-secondary {
+  background-color: var(--status-warning-secondary-background);
+  color: var(--status-warning-secondary-text);
+}
+.status-error-primary {
+  background-color: var(--status-error-primary-background);
+  color: var(--status-error-primary-text);
+}
+.status-error-secondary {
+  background-color: var(--status-error-secondary-background);
+  color: var(--status-error-secondary-text);
 }

--- a/packages/theme/src/themes/fram-theme/theme.css
+++ b/packages/theme/src/themes/fram-theme/theme.css
@@ -160,6 +160,23 @@
   --transport-transport_other-primary-text: #FFFFFF;
   --transport-transport_other-secondary-background: #4D4D4D;
   --transport-transport_other-secondary-text: #FFFFFF;
+
+  --status-valid-primary-background: #82B962;
+  --status-valid-primary-text: #000000;
+  --status-valid-secondary-background: #D6E8CB;
+  --status-valid-secondary-text: #000000;
+  --status-info-primary-background: #0A4C4F;
+  --status-info-primary-text: #FFFFFF;
+  --status-info-secondary-background: #CDE9E3;
+  --status-info-secondary-text: #000000;
+  --status-warning-primary-background: #FBDC00;
+  --status-warning-primary-text: #000000;
+  --status-warning-secondary-background: #FEF6BF;
+  --status-warning-secondary-text: #000000;
+  --status-error-primary-background: #E31B22;
+  --status-error-primary-text: #FFFFFF;
+  --status-error-secondary-background: #F9D2D3;
+  --status-error-secondary-text: #000000;
 }
 
 
@@ -323,6 +340,23 @@
   --transport-transport_other-primary-text: #FFFFFF;
   --transport-transport_other-secondary-background: #808080;
   --transport-transport_other-secondary-text: #000000;
+
+  --status-valid-primary-background: #82B962;
+  --status-valid-primary-text: #000000;
+  --status-valid-secondary-background: #38502B;
+  --status-valid-secondary-text: #FFFFFF;
+  --status-info-primary-background: #0A4C4F;
+  --status-info-primary-text: #FFFFFF;
+  --status-info-secondary-background: #073335;
+  --status-info-secondary-text: #FFFFFF;
+  --status-warning-primary-background: #FBDC00;
+  --status-warning-primary-text: #000000;
+  --status-warning-secondary-background: #3F3701;
+  --status-warning-secondary-text: #FFFFFF;
+  --status-error-primary-background: #E31B22;
+  --status-error-primary-text: #FFFFFF;
+  --status-error-secondary-background: #5B0C0E;
+  --status-error-secondary-text: #FFFFFF;
 }
 
 
@@ -486,6 +520,23 @@
   --transport-transport_other-primary-text: #FFFFFF;
   --transport-transport_other-secondary-background: #808080;
   --transport-transport_other-secondary-text: #000000;
+
+  --status-valid-primary-background: #82B962;
+  --status-valid-primary-text: #000000;
+  --status-valid-secondary-background: #38502B;
+  --status-valid-secondary-text: #FFFFFF;
+  --status-info-primary-background: #0A4C4F;
+  --status-info-primary-text: #FFFFFF;
+  --status-info-secondary-background: #073335;
+  --status-info-secondary-text: #FFFFFF;
+  --status-warning-primary-background: #FBDC00;
+  --status-warning-primary-text: #000000;
+  --status-warning-secondary-background: #3F3701;
+  --status-warning-secondary-text: #FFFFFF;
+  --status-error-primary-background: #E31B22;
+  --status-error-primary-text: #FFFFFF;
+  --status-error-secondary-background: #5B0C0E;
+  --status-error-secondary-text: #FFFFFF;
 }
 }
 
@@ -716,4 +767,37 @@
 .interactive-interactive_destructive:disabled {
   background-color: var(--interactive-interactive_destructive-disabled-background);
   color: var(--interactive-interactive_destructive-disabled-text);
+}
+
+.status-valid-primary {
+  background-color: var(--status-valid-primary-background);
+  color: var(--status-valid-primary-text);
+}
+.status-valid-secondary {
+  background-color: var(--status-valid-secondary-background);
+  color: var(--status-valid-secondary-text);
+}
+.status-info-primary {
+  background-color: var(--status-info-primary-background);
+  color: var(--status-info-primary-text);
+}
+.status-info-secondary {
+  background-color: var(--status-info-secondary-background);
+  color: var(--status-info-secondary-text);
+}
+.status-warning-primary {
+  background-color: var(--status-warning-primary-background);
+  color: var(--status-warning-primary-text);
+}
+.status-warning-secondary {
+  background-color: var(--status-warning-secondary-background);
+  color: var(--status-warning-secondary-text);
+}
+.status-error-primary {
+  background-color: var(--status-error-primary-background);
+  color: var(--status-error-primary-text);
+}
+.status-error-secondary {
+  background-color: var(--status-error-secondary-background);
+  color: var(--status-error-secondary-text);
 }

--- a/packages/theme/src/themes/fram-theme/theme.module.css
+++ b/packages/theme/src/themes/fram-theme/theme.module.css
@@ -160,6 +160,23 @@
   --transport-transport_other-primary-text: #FFFFFF;
   --transport-transport_other-secondary-background: #4D4D4D;
   --transport-transport_other-secondary-text: #FFFFFF;
+
+  --status-valid-primary-background: #82B962;
+  --status-valid-primary-text: #000000;
+  --status-valid-secondary-background: #D6E8CB;
+  --status-valid-secondary-text: #000000;
+  --status-info-primary-background: #0A4C4F;
+  --status-info-primary-text: #FFFFFF;
+  --status-info-secondary-background: #CDE9E3;
+  --status-info-secondary-text: #000000;
+  --status-warning-primary-background: #FBDC00;
+  --status-warning-primary-text: #000000;
+  --status-warning-secondary-background: #FEF6BF;
+  --status-warning-secondary-text: #000000;
+  --status-error-primary-background: #E31B22;
+  --status-error-primary-text: #FFFFFF;
+  --status-error-secondary-background: #F9D2D3;
+  --status-error-secondary-text: #000000;
 }
 
 
@@ -323,6 +340,23 @@
   --transport-transport_other-primary-text: #FFFFFF;
   --transport-transport_other-secondary-background: #808080;
   --transport-transport_other-secondary-text: #000000;
+
+  --status-valid-primary-background: #82B962;
+  --status-valid-primary-text: #000000;
+  --status-valid-secondary-background: #38502B;
+  --status-valid-secondary-text: #FFFFFF;
+  --status-info-primary-background: #0A4C4F;
+  --status-info-primary-text: #FFFFFF;
+  --status-info-secondary-background: #073335;
+  --status-info-secondary-text: #FFFFFF;
+  --status-warning-primary-background: #FBDC00;
+  --status-warning-primary-text: #000000;
+  --status-warning-secondary-background: #3F3701;
+  --status-warning-secondary-text: #FFFFFF;
+  --status-error-primary-background: #E31B22;
+  --status-error-primary-text: #FFFFFF;
+  --status-error-secondary-background: #5B0C0E;
+  --status-error-secondary-text: #FFFFFF;
 }
 
 
@@ -486,6 +520,23 @@
   --transport-transport_other-primary-text: #FFFFFF;
   --transport-transport_other-secondary-background: #808080;
   --transport-transport_other-secondary-text: #000000;
+
+  --status-valid-primary-background: #82B962;
+  --status-valid-primary-text: #000000;
+  --status-valid-secondary-background: #38502B;
+  --status-valid-secondary-text: #FFFFFF;
+  --status-info-primary-background: #0A4C4F;
+  --status-info-primary-text: #FFFFFF;
+  --status-info-secondary-background: #073335;
+  --status-info-secondary-text: #FFFFFF;
+  --status-warning-primary-background: #FBDC00;
+  --status-warning-primary-text: #000000;
+  --status-warning-secondary-background: #3F3701;
+  --status-warning-secondary-text: #FFFFFF;
+  --status-error-primary-background: #E31B22;
+  --status-error-primary-text: #FFFFFF;
+  --status-error-secondary-background: #5B0C0E;
+  --status-error-secondary-text: #FFFFFF;
 }
 }
 
@@ -716,4 +767,37 @@
 .interactive-interactive_destructive:disabled {
   background-color: var(--interactive-interactive_destructive-disabled-background);
   color: var(--interactive-interactive_destructive-disabled-text);
+}
+
+.status-valid-primary {
+  background-color: var(--status-valid-primary-background);
+  color: var(--status-valid-primary-text);
+}
+.status-valid-secondary {
+  background-color: var(--status-valid-secondary-background);
+  color: var(--status-valid-secondary-text);
+}
+.status-info-primary {
+  background-color: var(--status-info-primary-background);
+  color: var(--status-info-primary-text);
+}
+.status-info-secondary {
+  background-color: var(--status-info-secondary-background);
+  color: var(--status-info-secondary-text);
+}
+.status-warning-primary {
+  background-color: var(--status-warning-primary-background);
+  color: var(--status-warning-primary-text);
+}
+.status-warning-secondary {
+  background-color: var(--status-warning-secondary-background);
+  color: var(--status-warning-secondary-text);
+}
+.status-error-primary {
+  background-color: var(--status-error-primary-background);
+  color: var(--status-error-primary-text);
+}
+.status-error-secondary {
+  background-color: var(--status-error-secondary-background);
+  color: var(--status-error-secondary-text);
 }

--- a/packages/theme/src/themes/innlandet-theme/theme.css
+++ b/packages/theme/src/themes/innlandet-theme/theme.css
@@ -160,6 +160,23 @@
   --transport-transport_other-primary-text: #FFFFFF;
   --transport-transport_other-secondary-background: #2B343A;
   --transport-transport_other-secondary-text: #FFFFFF;
+
+  --status-valid-primary-background: #A2AD00;
+  --status-valid-primary-text: #000000;
+  --status-valid-secondary-background: #A2AD00;
+  --status-valid-secondary-text: #000000;
+  --status-info-primary-background: #71D6E0;
+  --status-info-primary-text: #000000;
+  --status-info-secondary-background: #71D6E0;
+  --status-info-secondary-text: #000000;
+  --status-warning-primary-background: #E4D700;
+  --status-warning-primary-text: #000000;
+  --status-warning-secondary-background: #E4D700;
+  --status-warning-secondary-text: #000000;
+  --status-error-primary-background: #A51140;
+  --status-error-primary-text: #FFFFFF;
+  --status-error-secondary-background: #A51140;
+  --status-error-secondary-text: #FFFFFF;
 }
 
 
@@ -323,6 +340,23 @@
   --transport-transport_other-primary-text: #000000;
   --transport-transport_other-secondary-background: #8D9398;
   --transport-transport_other-secondary-text: #000000;
+
+  --status-valid-primary-background: #A2AD00;
+  --status-valid-primary-text: #000000;
+  --status-valid-secondary-background: #A2AD00;
+  --status-valid-secondary-text: #000000;
+  --status-info-primary-background: #71D6E0;
+  --status-info-primary-text: #000000;
+  --status-info-secondary-background: #71D6E0;
+  --status-info-secondary-text: #000000;
+  --status-warning-primary-background: #E4D700;
+  --status-warning-primary-text: #000000;
+  --status-warning-secondary-background: #E4D700;
+  --status-warning-secondary-text: #000000;
+  --status-error-primary-background: #A51140;
+  --status-error-primary-text: #FFFFFF;
+  --status-error-secondary-background: #A51140;
+  --status-error-secondary-text: #FFFFFF;
 }
 
 
@@ -486,6 +520,23 @@
   --transport-transport_other-primary-text: #000000;
   --transport-transport_other-secondary-background: #8D9398;
   --transport-transport_other-secondary-text: #000000;
+
+  --status-valid-primary-background: #A2AD00;
+  --status-valid-primary-text: #000000;
+  --status-valid-secondary-background: #A2AD00;
+  --status-valid-secondary-text: #000000;
+  --status-info-primary-background: #71D6E0;
+  --status-info-primary-text: #000000;
+  --status-info-secondary-background: #71D6E0;
+  --status-info-secondary-text: #000000;
+  --status-warning-primary-background: #E4D700;
+  --status-warning-primary-text: #000000;
+  --status-warning-secondary-background: #E4D700;
+  --status-warning-secondary-text: #000000;
+  --status-error-primary-background: #A51140;
+  --status-error-primary-text: #FFFFFF;
+  --status-error-secondary-background: #A51140;
+  --status-error-secondary-text: #FFFFFF;
 }
 }
 
@@ -716,4 +767,37 @@
 .interactive-interactive_destructive:disabled {
   background-color: var(--interactive-interactive_destructive-disabled-background);
   color: var(--interactive-interactive_destructive-disabled-text);
+}
+
+.status-valid-primary {
+  background-color: var(--status-valid-primary-background);
+  color: var(--status-valid-primary-text);
+}
+.status-valid-secondary {
+  background-color: var(--status-valid-secondary-background);
+  color: var(--status-valid-secondary-text);
+}
+.status-info-primary {
+  background-color: var(--status-info-primary-background);
+  color: var(--status-info-primary-text);
+}
+.status-info-secondary {
+  background-color: var(--status-info-secondary-background);
+  color: var(--status-info-secondary-text);
+}
+.status-warning-primary {
+  background-color: var(--status-warning-primary-background);
+  color: var(--status-warning-primary-text);
+}
+.status-warning-secondary {
+  background-color: var(--status-warning-secondary-background);
+  color: var(--status-warning-secondary-text);
+}
+.status-error-primary {
+  background-color: var(--status-error-primary-background);
+  color: var(--status-error-primary-text);
+}
+.status-error-secondary {
+  background-color: var(--status-error-secondary-background);
+  color: var(--status-error-secondary-text);
 }

--- a/packages/theme/src/themes/innlandet-theme/theme.module.css
+++ b/packages/theme/src/themes/innlandet-theme/theme.module.css
@@ -160,6 +160,23 @@
   --transport-transport_other-primary-text: #FFFFFF;
   --transport-transport_other-secondary-background: #2B343A;
   --transport-transport_other-secondary-text: #FFFFFF;
+
+  --status-valid-primary-background: #A2AD00;
+  --status-valid-primary-text: #000000;
+  --status-valid-secondary-background: #A2AD00;
+  --status-valid-secondary-text: #000000;
+  --status-info-primary-background: #71D6E0;
+  --status-info-primary-text: #000000;
+  --status-info-secondary-background: #71D6E0;
+  --status-info-secondary-text: #000000;
+  --status-warning-primary-background: #E4D700;
+  --status-warning-primary-text: #000000;
+  --status-warning-secondary-background: #E4D700;
+  --status-warning-secondary-text: #000000;
+  --status-error-primary-background: #A51140;
+  --status-error-primary-text: #FFFFFF;
+  --status-error-secondary-background: #A51140;
+  --status-error-secondary-text: #FFFFFF;
 }
 
 
@@ -323,6 +340,23 @@
   --transport-transport_other-primary-text: #000000;
   --transport-transport_other-secondary-background: #8D9398;
   --transport-transport_other-secondary-text: #000000;
+
+  --status-valid-primary-background: #A2AD00;
+  --status-valid-primary-text: #000000;
+  --status-valid-secondary-background: #A2AD00;
+  --status-valid-secondary-text: #000000;
+  --status-info-primary-background: #71D6E0;
+  --status-info-primary-text: #000000;
+  --status-info-secondary-background: #71D6E0;
+  --status-info-secondary-text: #000000;
+  --status-warning-primary-background: #E4D700;
+  --status-warning-primary-text: #000000;
+  --status-warning-secondary-background: #E4D700;
+  --status-warning-secondary-text: #000000;
+  --status-error-primary-background: #A51140;
+  --status-error-primary-text: #FFFFFF;
+  --status-error-secondary-background: #A51140;
+  --status-error-secondary-text: #FFFFFF;
 }
 
 
@@ -486,6 +520,23 @@
   --transport-transport_other-primary-text: #000000;
   --transport-transport_other-secondary-background: #8D9398;
   --transport-transport_other-secondary-text: #000000;
+
+  --status-valid-primary-background: #A2AD00;
+  --status-valid-primary-text: #000000;
+  --status-valid-secondary-background: #A2AD00;
+  --status-valid-secondary-text: #000000;
+  --status-info-primary-background: #71D6E0;
+  --status-info-primary-text: #000000;
+  --status-info-secondary-background: #71D6E0;
+  --status-info-secondary-text: #000000;
+  --status-warning-primary-background: #E4D700;
+  --status-warning-primary-text: #000000;
+  --status-warning-secondary-background: #E4D700;
+  --status-warning-secondary-text: #000000;
+  --status-error-primary-background: #A51140;
+  --status-error-primary-text: #FFFFFF;
+  --status-error-secondary-background: #A51140;
+  --status-error-secondary-text: #FFFFFF;
 }
 }
 
@@ -716,4 +767,37 @@
 .interactive-interactive_destructive:disabled {
   background-color: var(--interactive-interactive_destructive-disabled-background);
   color: var(--interactive-interactive_destructive-disabled-text);
+}
+
+.status-valid-primary {
+  background-color: var(--status-valid-primary-background);
+  color: var(--status-valid-primary-text);
+}
+.status-valid-secondary {
+  background-color: var(--status-valid-secondary-background);
+  color: var(--status-valid-secondary-text);
+}
+.status-info-primary {
+  background-color: var(--status-info-primary-background);
+  color: var(--status-info-primary-text);
+}
+.status-info-secondary {
+  background-color: var(--status-info-secondary-background);
+  color: var(--status-info-secondary-text);
+}
+.status-warning-primary {
+  background-color: var(--status-warning-primary-background);
+  color: var(--status-warning-primary-text);
+}
+.status-warning-secondary {
+  background-color: var(--status-warning-secondary-background);
+  color: var(--status-warning-secondary-text);
+}
+.status-error-primary {
+  background-color: var(--status-error-primary-background);
+  color: var(--status-error-primary-text);
+}
+.status-error-secondary {
+  background-color: var(--status-error-secondary-background);
+  color: var(--status-error-secondary-text);
 }

--- a/packages/theme/src/themes/nfk-theme/theme.css
+++ b/packages/theme/src/themes/nfk-theme/theme.css
@@ -160,6 +160,23 @@
   --transport-transport_other-primary-text: #FFFFFF;
   --transport-transport_other-secondary-background: #717171;
   --transport-transport_other-secondary-text: #FFFFFF;
+
+  --status-valid-primary-background: #7FDABB;
+  --status-valid-primary-text: #003441;
+  --status-valid-secondary-background: #7FDABB;
+  --status-valid-secondary-text: #003441;
+  --status-info-primary-background: #99CDDA;
+  --status-info-primary-text: #003441;
+  --status-info-secondary-background: #99CDDA;
+  --status-info-secondary-text: #003441;
+  --status-warning-primary-background: #FCBA63;
+  --status-warning-primary-text: #003441;
+  --status-warning-secondary-background: #FCBA63;
+  --status-warning-secondary-text: #003441;
+  --status-error-primary-background: #A61419;
+  --status-error-primary-text: #FFFFFF;
+  --status-error-secondary-background: #A61419;
+  --status-error-secondary-text: #FFFFFF;
 }
 
 
@@ -323,6 +340,23 @@
   --transport-transport_other-primary-text: #FFFFFF;
   --transport-transport_other-secondary-background: #9C9C9C;
   --transport-transport_other-secondary-text: #FFFFFF;
+
+  --status-valid-primary-background: #7FDABB;
+  --status-valid-primary-text: #003441;
+  --status-valid-secondary-background: #7FDABB;
+  --status-valid-secondary-text: #003441;
+  --status-info-primary-background: #99CDDA;
+  --status-info-primary-text: #003441;
+  --status-info-secondary-background: #99CDDA;
+  --status-info-secondary-text: #003441;
+  --status-warning-primary-background: #FCBA63;
+  --status-warning-primary-text: #003441;
+  --status-warning-secondary-background: #FCBA63;
+  --status-warning-secondary-text: #003441;
+  --status-error-primary-background: #BE161D;
+  --status-error-primary-text: #FFFFFF;
+  --status-error-secondary-background: #BE161D;
+  --status-error-secondary-text: #FFFFFF;
 }
 
 
@@ -486,6 +520,23 @@
   --transport-transport_other-primary-text: #FFFFFF;
   --transport-transport_other-secondary-background: #9C9C9C;
   --transport-transport_other-secondary-text: #FFFFFF;
+
+  --status-valid-primary-background: #7FDABB;
+  --status-valid-primary-text: #003441;
+  --status-valid-secondary-background: #7FDABB;
+  --status-valid-secondary-text: #003441;
+  --status-info-primary-background: #99CDDA;
+  --status-info-primary-text: #003441;
+  --status-info-secondary-background: #99CDDA;
+  --status-info-secondary-text: #003441;
+  --status-warning-primary-background: #FCBA63;
+  --status-warning-primary-text: #003441;
+  --status-warning-secondary-background: #FCBA63;
+  --status-warning-secondary-text: #003441;
+  --status-error-primary-background: #BE161D;
+  --status-error-primary-text: #FFFFFF;
+  --status-error-secondary-background: #BE161D;
+  --status-error-secondary-text: #FFFFFF;
 }
 }
 
@@ -716,4 +767,37 @@
 .interactive-interactive_destructive:disabled {
   background-color: var(--interactive-interactive_destructive-disabled-background);
   color: var(--interactive-interactive_destructive-disabled-text);
+}
+
+.status-valid-primary {
+  background-color: var(--status-valid-primary-background);
+  color: var(--status-valid-primary-text);
+}
+.status-valid-secondary {
+  background-color: var(--status-valid-secondary-background);
+  color: var(--status-valid-secondary-text);
+}
+.status-info-primary {
+  background-color: var(--status-info-primary-background);
+  color: var(--status-info-primary-text);
+}
+.status-info-secondary {
+  background-color: var(--status-info-secondary-background);
+  color: var(--status-info-secondary-text);
+}
+.status-warning-primary {
+  background-color: var(--status-warning-primary-background);
+  color: var(--status-warning-primary-text);
+}
+.status-warning-secondary {
+  background-color: var(--status-warning-secondary-background);
+  color: var(--status-warning-secondary-text);
+}
+.status-error-primary {
+  background-color: var(--status-error-primary-background);
+  color: var(--status-error-primary-text);
+}
+.status-error-secondary {
+  background-color: var(--status-error-secondary-background);
+  color: var(--status-error-secondary-text);
 }

--- a/packages/theme/src/themes/nfk-theme/theme.module.css
+++ b/packages/theme/src/themes/nfk-theme/theme.module.css
@@ -160,6 +160,23 @@
   --transport-transport_other-primary-text: #FFFFFF;
   --transport-transport_other-secondary-background: #717171;
   --transport-transport_other-secondary-text: #FFFFFF;
+
+  --status-valid-primary-background: #7FDABB;
+  --status-valid-primary-text: #003441;
+  --status-valid-secondary-background: #7FDABB;
+  --status-valid-secondary-text: #003441;
+  --status-info-primary-background: #99CDDA;
+  --status-info-primary-text: #003441;
+  --status-info-secondary-background: #99CDDA;
+  --status-info-secondary-text: #003441;
+  --status-warning-primary-background: #FCBA63;
+  --status-warning-primary-text: #003441;
+  --status-warning-secondary-background: #FCBA63;
+  --status-warning-secondary-text: #003441;
+  --status-error-primary-background: #A61419;
+  --status-error-primary-text: #FFFFFF;
+  --status-error-secondary-background: #A61419;
+  --status-error-secondary-text: #FFFFFF;
 }
 
 
@@ -323,6 +340,23 @@
   --transport-transport_other-primary-text: #FFFFFF;
   --transport-transport_other-secondary-background: #9C9C9C;
   --transport-transport_other-secondary-text: #FFFFFF;
+
+  --status-valid-primary-background: #7FDABB;
+  --status-valid-primary-text: #003441;
+  --status-valid-secondary-background: #7FDABB;
+  --status-valid-secondary-text: #003441;
+  --status-info-primary-background: #99CDDA;
+  --status-info-primary-text: #003441;
+  --status-info-secondary-background: #99CDDA;
+  --status-info-secondary-text: #003441;
+  --status-warning-primary-background: #FCBA63;
+  --status-warning-primary-text: #003441;
+  --status-warning-secondary-background: #FCBA63;
+  --status-warning-secondary-text: #003441;
+  --status-error-primary-background: #BE161D;
+  --status-error-primary-text: #FFFFFF;
+  --status-error-secondary-background: #BE161D;
+  --status-error-secondary-text: #FFFFFF;
 }
 
 
@@ -486,6 +520,23 @@
   --transport-transport_other-primary-text: #FFFFFF;
   --transport-transport_other-secondary-background: #9C9C9C;
   --transport-transport_other-secondary-text: #FFFFFF;
+
+  --status-valid-primary-background: #7FDABB;
+  --status-valid-primary-text: #003441;
+  --status-valid-secondary-background: #7FDABB;
+  --status-valid-secondary-text: #003441;
+  --status-info-primary-background: #99CDDA;
+  --status-info-primary-text: #003441;
+  --status-info-secondary-background: #99CDDA;
+  --status-info-secondary-text: #003441;
+  --status-warning-primary-background: #FCBA63;
+  --status-warning-primary-text: #003441;
+  --status-warning-secondary-background: #FCBA63;
+  --status-warning-secondary-text: #003441;
+  --status-error-primary-background: #BE161D;
+  --status-error-primary-text: #FFFFFF;
+  --status-error-secondary-background: #BE161D;
+  --status-error-secondary-text: #FFFFFF;
 }
 }
 
@@ -716,4 +767,37 @@
 .interactive-interactive_destructive:disabled {
   background-color: var(--interactive-interactive_destructive-disabled-background);
   color: var(--interactive-interactive_destructive-disabled-text);
+}
+
+.status-valid-primary {
+  background-color: var(--status-valid-primary-background);
+  color: var(--status-valid-primary-text);
+}
+.status-valid-secondary {
+  background-color: var(--status-valid-secondary-background);
+  color: var(--status-valid-secondary-text);
+}
+.status-info-primary {
+  background-color: var(--status-info-primary-background);
+  color: var(--status-info-primary-text);
+}
+.status-info-secondary {
+  background-color: var(--status-info-secondary-background);
+  color: var(--status-info-secondary-text);
+}
+.status-warning-primary {
+  background-color: var(--status-warning-primary-background);
+  color: var(--status-warning-primary-text);
+}
+.status-warning-secondary {
+  background-color: var(--status-warning-secondary-background);
+  color: var(--status-warning-secondary-text);
+}
+.status-error-primary {
+  background-color: var(--status-error-primary-background);
+  color: var(--status-error-primary-text);
+}
+.status-error-secondary {
+  background-color: var(--status-error-secondary-background);
+  color: var(--status-error-secondary-text);
 }

--- a/packages/theme/src/themes/troms-theme/theme.css
+++ b/packages/theme/src/themes/troms-theme/theme.css
@@ -160,6 +160,23 @@
   --transport-transport_other-primary-text: #FFFFFF;
   --transport-transport_other-secondary-background: #2B343A;
   --transport-transport_other-secondary-text: #FFFFFF;
+
+  --status-valid-primary-background: #6B9956;
+  --status-valid-primary-text: #000000;
+  --status-valid-secondary-background: #6B9956;
+  --status-valid-secondary-text: #000000;
+  --status-info-primary-background: #546AD6;
+  --status-info-primary-text: #FFFFFF;
+  --status-info-secondary-background: #546AD6;
+  --status-info-secondary-text: #FFFFFF;
+  --status-warning-primary-background: #E6D220;
+  --status-warning-primary-text: #000000;
+  --status-warning-secondary-background: #E6D220;
+  --status-warning-secondary-text: #000000;
+  --status-error-primary-background: #DB6364;
+  --status-error-primary-text: #000000;
+  --status-error-secondary-background: #DB6364;
+  --status-error-secondary-text: #000000;
 }
 
 
@@ -323,6 +340,23 @@
   --transport-transport_other-primary-text: #000000;
   --transport-transport_other-secondary-background: #8D9398;
   --transport-transport_other-secondary-text: #000000;
+
+  --status-valid-primary-background: #6B9956;
+  --status-valid-primary-text: #000000;
+  --status-valid-secondary-background: #6B9956;
+  --status-valid-secondary-text: #000000;
+  --status-info-primary-background: #546AD6;
+  --status-info-primary-text: #FFFFFF;
+  --status-info-secondary-background: #546AD6;
+  --status-info-secondary-text: #FFFFFF;
+  --status-warning-primary-background: #E6D220;
+  --status-warning-primary-text: #000000;
+  --status-warning-secondary-background: #E6D220;
+  --status-warning-secondary-text: #000000;
+  --status-error-primary-background: #DB6364;
+  --status-error-primary-text: #000000;
+  --status-error-secondary-background: #DB6364;
+  --status-error-secondary-text: #000000;
 }
 
 
@@ -486,6 +520,23 @@
   --transport-transport_other-primary-text: #000000;
   --transport-transport_other-secondary-background: #8D9398;
   --transport-transport_other-secondary-text: #000000;
+
+  --status-valid-primary-background: #6B9956;
+  --status-valid-primary-text: #000000;
+  --status-valid-secondary-background: #6B9956;
+  --status-valid-secondary-text: #000000;
+  --status-info-primary-background: #546AD6;
+  --status-info-primary-text: #FFFFFF;
+  --status-info-secondary-background: #546AD6;
+  --status-info-secondary-text: #FFFFFF;
+  --status-warning-primary-background: #E6D220;
+  --status-warning-primary-text: #000000;
+  --status-warning-secondary-background: #E6D220;
+  --status-warning-secondary-text: #000000;
+  --status-error-primary-background: #DB6364;
+  --status-error-primary-text: #000000;
+  --status-error-secondary-background: #DB6364;
+  --status-error-secondary-text: #000000;
 }
 }
 
@@ -716,4 +767,37 @@
 .interactive-interactive_destructive:disabled {
   background-color: var(--interactive-interactive_destructive-disabled-background);
   color: var(--interactive-interactive_destructive-disabled-text);
+}
+
+.status-valid-primary {
+  background-color: var(--status-valid-primary-background);
+  color: var(--status-valid-primary-text);
+}
+.status-valid-secondary {
+  background-color: var(--status-valid-secondary-background);
+  color: var(--status-valid-secondary-text);
+}
+.status-info-primary {
+  background-color: var(--status-info-primary-background);
+  color: var(--status-info-primary-text);
+}
+.status-info-secondary {
+  background-color: var(--status-info-secondary-background);
+  color: var(--status-info-secondary-text);
+}
+.status-warning-primary {
+  background-color: var(--status-warning-primary-background);
+  color: var(--status-warning-primary-text);
+}
+.status-warning-secondary {
+  background-color: var(--status-warning-secondary-background);
+  color: var(--status-warning-secondary-text);
+}
+.status-error-primary {
+  background-color: var(--status-error-primary-background);
+  color: var(--status-error-primary-text);
+}
+.status-error-secondary {
+  background-color: var(--status-error-secondary-background);
+  color: var(--status-error-secondary-text);
 }

--- a/packages/theme/src/themes/troms-theme/theme.module.css
+++ b/packages/theme/src/themes/troms-theme/theme.module.css
@@ -160,6 +160,23 @@
   --transport-transport_other-primary-text: #FFFFFF;
   --transport-transport_other-secondary-background: #2B343A;
   --transport-transport_other-secondary-text: #FFFFFF;
+
+  --status-valid-primary-background: #6B9956;
+  --status-valid-primary-text: #000000;
+  --status-valid-secondary-background: #6B9956;
+  --status-valid-secondary-text: #000000;
+  --status-info-primary-background: #546AD6;
+  --status-info-primary-text: #FFFFFF;
+  --status-info-secondary-background: #546AD6;
+  --status-info-secondary-text: #FFFFFF;
+  --status-warning-primary-background: #E6D220;
+  --status-warning-primary-text: #000000;
+  --status-warning-secondary-background: #E6D220;
+  --status-warning-secondary-text: #000000;
+  --status-error-primary-background: #DB6364;
+  --status-error-primary-text: #000000;
+  --status-error-secondary-background: #DB6364;
+  --status-error-secondary-text: #000000;
 }
 
 
@@ -323,6 +340,23 @@
   --transport-transport_other-primary-text: #000000;
   --transport-transport_other-secondary-background: #8D9398;
   --transport-transport_other-secondary-text: #000000;
+
+  --status-valid-primary-background: #6B9956;
+  --status-valid-primary-text: #000000;
+  --status-valid-secondary-background: #6B9956;
+  --status-valid-secondary-text: #000000;
+  --status-info-primary-background: #546AD6;
+  --status-info-primary-text: #FFFFFF;
+  --status-info-secondary-background: #546AD6;
+  --status-info-secondary-text: #FFFFFF;
+  --status-warning-primary-background: #E6D220;
+  --status-warning-primary-text: #000000;
+  --status-warning-secondary-background: #E6D220;
+  --status-warning-secondary-text: #000000;
+  --status-error-primary-background: #DB6364;
+  --status-error-primary-text: #000000;
+  --status-error-secondary-background: #DB6364;
+  --status-error-secondary-text: #000000;
 }
 
 
@@ -486,6 +520,23 @@
   --transport-transport_other-primary-text: #000000;
   --transport-transport_other-secondary-background: #8D9398;
   --transport-transport_other-secondary-text: #000000;
+
+  --status-valid-primary-background: #6B9956;
+  --status-valid-primary-text: #000000;
+  --status-valid-secondary-background: #6B9956;
+  --status-valid-secondary-text: #000000;
+  --status-info-primary-background: #546AD6;
+  --status-info-primary-text: #FFFFFF;
+  --status-info-secondary-background: #546AD6;
+  --status-info-secondary-text: #FFFFFF;
+  --status-warning-primary-background: #E6D220;
+  --status-warning-primary-text: #000000;
+  --status-warning-secondary-background: #E6D220;
+  --status-warning-secondary-text: #000000;
+  --status-error-primary-background: #DB6364;
+  --status-error-primary-text: #000000;
+  --status-error-secondary-background: #DB6364;
+  --status-error-secondary-text: #000000;
 }
 }
 
@@ -716,4 +767,37 @@
 .interactive-interactive_destructive:disabled {
   background-color: var(--interactive-interactive_destructive-disabled-background);
   color: var(--interactive-interactive_destructive-disabled-text);
+}
+
+.status-valid-primary {
+  background-color: var(--status-valid-primary-background);
+  color: var(--status-valid-primary-text);
+}
+.status-valid-secondary {
+  background-color: var(--status-valid-secondary-background);
+  color: var(--status-valid-secondary-text);
+}
+.status-info-primary {
+  background-color: var(--status-info-primary-background);
+  color: var(--status-info-primary-text);
+}
+.status-info-secondary {
+  background-color: var(--status-info-secondary-background);
+  color: var(--status-info-secondary-text);
+}
+.status-warning-primary {
+  background-color: var(--status-warning-primary-background);
+  color: var(--status-warning-primary-text);
+}
+.status-warning-secondary {
+  background-color: var(--status-warning-secondary-background);
+  color: var(--status-warning-secondary-text);
+}
+.status-error-primary {
+  background-color: var(--status-error-primary-background);
+  color: var(--status-error-primary-text);
+}
+.status-error-secondary {
+  background-color: var(--status-error-secondary-background);
+  color: var(--status-error-secondary-text);
 }

--- a/packages/theme/tools/create-theme.ts
+++ b/packages/theme/tools/create-theme.ts
@@ -3,6 +3,7 @@ import {writeFile} from 'fs/promises';
 import {join} from 'path';
 import {ContrastColor, Mode, Theme, InteractiveColor} from '../src';
 import {indentJoin, maybeConvertToRem} from './utils';
+import {StatusColor} from "../lib";
 
 export default async function outputThemes(
   themeOutputDirName: string,
@@ -35,6 +36,8 @@ ${printContrastColors('static', themes.light.static)}
 ${printContrastColors('transport', themes.light.transport)}
 
 ${printInteractiveColors('interactive', themes.light.interactive)}
+
+${printStatusColors('status', themes.light.status)}
 `;
 }
 
@@ -58,6 +61,8 @@ ${extract('static')}
 ${extract('interactive')}
 
 ${extract('transport')}
+
+${extract('status')}
 }
 `;
 }
@@ -81,6 +86,8 @@ ${extract('static')}
 ${extract('interactive')}
 
 ${extract('transport')}
+
+${extract('status')}
 }
 }
 `;
@@ -94,7 +101,7 @@ function printWithPrefix<T>(
 ) {
   let data: string[] = [];
   for (let [name, colorValue] of Object.entries(obj)) {
-    if (isContrastColor(colorValue)) {
+    if (isContrastColor(colorValue) || (isStatusColor(colorValue))) {
       const {...withoutText} = colorValue;
       data = data.concat(
         printWithPrefix(`${prefix}-${name}`, withoutText, valueConvert),
@@ -155,6 +162,22 @@ function printInteractiveColors(
   return data.join('\n');
 }
 
+function printStatusColors(
+  name: string,
+  obj: ObjColors,
+  prefix: string = '',
+) {
+  let data: string[] = [];
+  for (let key in obj) {
+    const val = obj[key];
+    if (isStatusColor(val)) {
+      return printContrastColors(name, obj, prefix);
+    }
+  }
+  return data.join('\n');
+}
+
+
 function isContrastColor(a: any): a is ContrastColor {
   return typeof a === 'object' && 'background' in a && 'text' in a;
 }
@@ -167,5 +190,13 @@ function isInteractive(a: any): a is InteractiveColor {
     'active' in a &&
     'disabled' in a &&
     'outline' in a
+  );
+}
+
+function isStatusColor(a: any): a is StatusColor {
+  return (
+    typeof a === 'object' &&
+    'primary' in a &&
+    'secondary' in a
   );
 }


### PR DESCRIPTION
After the status colors were split out into their own set of colors (and not under static), their colors were not generated in the CSS. 

This is more than likely a breaking change in some of the applications, should preferrably have been in the same version as the changes in TypeScript, please comment on how we best should solve this.

Closes https://github.com/AtB-AS/kundevendt/issues/18515