### PR TITLE
fix: fram webshop footer color

### DIFF
--- a/packages/theme/src/themes/fram-theme/theme.css
+++ b/packages/theme/src/themes/fram-theme/theme.css
@@ -44,8 +44,8 @@
   --static-background-background_accent_3-text: #FFFFFF;
   --static-background-background_accent_4-background: #F0E991;
   --static-background-background_accent_4-text: #000000;
-  --static-background-background_accent_5-background: #99CAE2;
-  --static-background-background_accent_5-text: #000000;
+  --static-background-background_accent_5-background: #007AB5;
+  --static-background-background_accent_5-text: #FFFFFF;
   --static-zone_selection-from-background: #82B962;
   --static-zone_selection-from-text: #000000;
   --static-zone_selection-to-background: #005686;

--- a/packages/theme/src/themes/fram-theme/theme.module.css
+++ b/packages/theme/src/themes/fram-theme/theme.module.css
@@ -44,8 +44,8 @@
   --static-background-background_accent_3-text: #FFFFFF;
   --static-background-background_accent_4-background: #F0E991;
   --static-background-background_accent_4-text: #000000;
-  --static-background-background_accent_5-background: #99CAE2;
-  --static-background-background_accent_5-text: #000000;
+  --static-background-background_accent_5-background: #007AB5;
+  --static-background-background_accent_5-text: #FFFFFF;
   --static-zone_selection-from-background: #82B962;
   --static-zone_selection-from-text: #000000;
   --static-zone_selection-to-background: #005686;

--- a/packages/theme/src/themes/fram-theme/theme.ts
+++ b/packages/theme/src/themes/fram-theme/theme.ts
@@ -372,7 +372,7 @@ const themes: Themes = {
         background_accent_2: baseColors.blue_logo_100,
         background_accent_3: baseColors.marine_dark_600,
         background_accent_4: baseColors.yellow_logo_200,
-        background_accent_5: baseColors.blue_logo_200,
+        background_accent_5: baseColors.blue_logo_500,
       },
       zone_selection: {
         from: baseColors.green_light_300,


### PR DESCRIPTION
FRAM wanted their navbar and footer to be the same color some time ago. The recent color changes changed this. This causes issues because FRAM uses the FRAM logo in the navbar and footer, meaning one logo color should be possible to use in both places. I propose that we change the footer color to match the navbar color in light mode, as was done earlier so that the webshop feels more aligned with their homepage frammr.no and also fixes the problem with the logo. The color is only used by the webshop so this won't cause any other issues. 

Current colors:

<img width="1306" alt="image" src="https://github.com/AtB-AS/design-system/assets/43166974/d0295d9d-949d-48ff-adba-c72404d492db">

With this change:

<img width="1302" alt="image" src="https://github.com/AtB-AS/design-system/assets/43166974/06b4f63d-7317-49f9-9f63-0f9941b76c4b">



