### PR TITLE
feat: Added compatibility mode to convert new Figma structure to old (web) app structure

### DIFF
--- a/packages/theme/package.json
+++ b/packages/theme/package.json
@@ -15,7 +15,7 @@
     "tsc": "tsc",
     "clean": "rm -rf lib",
     "test": "echo \"Error: run tests from root\" && exit 1",
-    "build": "yarn fetch-variables && tsc -p tsconfig.build.json",
+    "build": "yarn fetch-variables && tsc -p tsconfig.build.json && yarn create-css && yarn copy-css",
     "copy-css": "copyfiles -u 1 \"src/**/*.{css,woff,woff2,ttf,eot,svg,png}\" lib/",
     "create-css": "tsx ./tools/create-css.ts",
     "fetch-variables": "tsx ./tools/fetch-figma-variables.ts"

--- a/packages/theme/package.json
+++ b/packages/theme/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@atb-as/theme",
-  "version": "11.0.0-alpha.6",
+  "version": "11.0.0-alpha.7",
   "private": false,
   "description": "AtB Design System Colors",
   "license": "EUPL-1.2",

--- a/packages/theme/src/theme.ts
+++ b/packages/theme/src/theme.ts
@@ -1,5 +1,5 @@
 import merge from 'ts-deepmerge';
-import { ConfigurationOverride, overrideConfig } from './utils/override-config';
+import {ConfigurationOverride, overrideConfig} from './utils/override-config';
 import {
   AtBThemes,
   // NfkThemes,
@@ -13,19 +13,14 @@ export type Themes = {
 };
 export type Mode = keyof Themes;
 
+export type TextColor = 'primary' | 'secondary' | 'disabled';
+
 export type TextColorType = 'dark' | 'light';
 
 export type ContrastColor = {
   background: string;
-  foreground: {
-    primary: string;
-    secondary: string;
-    disabled: string;
-  };
+  text: string;
 };
-
-export type TextColor = keyof ContrastColor["foreground"];
-
 export type TransportColor = {
   primary: ContrastColor;
   secondary: ContrastColor;
@@ -67,85 +62,81 @@ export type GeofencingZoneStyles = {
 };
 
 export interface Theme {
-  color: {
-    foreground: {
-      dark: ContrastColor['foreground'];
-      light: ContrastColor['foreground'];
-      dynamic: ContrastColor['foreground'];
-      inverse: ContrastColor['foreground'];
-    };
+  spacings: {
+    xSmall: number;
+    small: number;
+    medium: number;
+    large: number;
+    xLarge: number;
+  };
 
-    interactive: {
-      0: InteractiveColor;
-      1: InteractiveColor;
-      2: InteractiveColor;
-      3: InteractiveColor;
-      destructive: InteractiveColor;
-    };
+  interactive: {
+    interactive_0: InteractiveColor;
+    interactive_1: InteractiveColor;
+    interactive_2: InteractiveColor;
+    interactive_3: InteractiveColor;
+    interactive_destructive: InteractiveColor;
+  };
+  transport: {
+    transport_city: TransportColor;
+    transport_region: TransportColor;
+    transport_airportExpress: TransportColor;
+    transport_boat: TransportColor;
+    transport_train: TransportColor;
+    transport_flexible: TransportColor;
+    transport_scooter: TransportColor;
+    transport_bike: TransportColor;
+    transport_car: TransportColor;
+    transport_other: TransportColor;
+  };
 
-    transport: {
-      city: TransportColor;
-      region: TransportColor;
-      airportExpress: TransportColor;
-      boat: TransportColor;
-      train: TransportColor;
-      flexible: TransportColor;
-      scooter: TransportColor;
-      bike: TransportColor;
-      car: TransportColor;
-      other: TransportColor;
-    };
+  status: {
+    valid: StatusColor;
+    info: StatusColor;
+    warning: StatusColor;
+    error: StatusColor;
+  };
 
-    status: {
-      valid: StatusColor;
-      info: StatusColor;
-      warning: StatusColor;
-      error: StatusColor;
-    };
-
+  static: {
     background: {
-      neutral: {
-        0: ContrastColor;
-        1: ContrastColor;
-        2: ContrastColor;
-        3: ContrastColor;
-      };
-      accent: {
-        0: ContrastColor;
-        1: ContrastColor;
-        2: ContrastColor;
-        3: ContrastColor;
-        4: ContrastColor;
-        5: ContrastColor;
-      };
+      background_0: ContrastColor;
+      background_1: ContrastColor;
+      background_2: ContrastColor;
+      background_3: ContrastColor;
+      background_accent_0: ContrastColor;
+      background_accent_1: ContrastColor;
+      background_accent_2: ContrastColor;
+      background_accent_3: ContrastColor;
+      background_accent_4: ContrastColor;
+      background_accent_5: ContrastColor;
     };
 
-    zone: {
+    zone_selection: {
       from: ContrastColor;
       to: ContrastColor;
     };
+  };
 
-    geofencingZone: GeofencingZoneStyles;
-
-    border: {
-      primary: ContrastColor;
-      secondary: ContrastColor;
-      focus: ContrastColor;
-    };
+  text: {
+    colors: {[key in TextColor]: string};
   };
 
   border: {
-    radius: {
-      small: number;
-      medium: number;
-      circle: number;
-    };
-    width: {
-      slim: number;
-      medium: number;
+    primary: string;
+    secondary: string;
+    focus: string;
+    border: {
+      radius: {
+        small: number;
+        regular: number;
+        circle: number;
+      };
+      width: {
+        slim: number;
+        medium: number;
+      };
     };
   };
-
   icon: {
     size: {
       xSmall: number;
@@ -154,34 +145,10 @@ export interface Theme {
       large: number;
     }
   };
+  geofencingZones: GeofencingZoneStyles;
+}
 
-  spacing: {
-    xSmall: number;
-    small: number;
-    medium: number;
-    large: number;
-    xLarge: number;
-  };
-
-  typography: {
-    ios: {
-      font: string;
-      number: number;
-    };
-
-    android: {
-      font: string;
-      number: number;
-    };
-
-    web: {
-      font: string;
-      number: number;
-    };
-  };
-};
-
-export type Statuses = keyof Theme['color']['status'];
+export type Statuses = keyof Theme['status'];
 
 export enum ThemeVariant {
   AtB,

--- a/packages/theme/src/theme.ts
+++ b/packages/theme/src/theme.ts
@@ -7,9 +7,18 @@ import {
   // TromsThemes,
   // InnlandetThemes,
 } from './themes';
-export type Themes = {
-  light: Theme;
-  dark: Theme;
+
+import {
+  AtBThemesFs,
+  // NfkThemes,
+  // FRAMThemes,
+  // TromsThemes,
+  // InnlandetThemes,
+} from './themes-fs';
+
+export type Themes<T = Theme> = {
+  light: T;
+  dark: T;
 };
 export type Mode = keyof Themes;
 
@@ -21,23 +30,22 @@ export type ContrastColor = {
   background: string;
   text: string;
 };
-export type TransportColor = {
-  primary: ContrastColor;
-  secondary: ContrastColor;
+export type TransportColor<T = ContrastColor> = {
+  primary: T;
+  secondary: T;
 };
 
-export type StatusColor = {
-  primary: ContrastColor;
-  secondary: ContrastColor;
+export type StatusColor<T = ContrastColor> = {
+  primary: T;
+  secondary: T;
 };
 
-export type InteractiveColor = {
-  default: ContrastColor;
-  hover: ContrastColor;
-  active: ContrastColor;
-  disabled: ContrastColor;
-  outline: ContrastColor;
-  destructive: ContrastColor;
+export type InteractiveColor<T = ContrastColor> = {
+  default: T;
+  hover: T;
+  active: T;
+  disabled: T;
+  outline: T;
 };
 
 // The colors can be changed, but should follow standard practice as commented:
@@ -50,15 +58,15 @@ export enum GeofencingZoneCodes {
 
 export type GeofencingZoneKeys = keyof typeof GeofencingZoneCodes;
 
-export type GeofencingZoneStyle = {
-  color: ContrastColor;
+export type GeofencingZoneStyle<T = ContrastColor> = {
+  color: T;
   fillOpacity: number;
   strokeOpacity: number;
   layerIndexWeight: number;
 };
 
-export type GeofencingZoneStyles = {
-  [GZKey in GeofencingZoneKeys]: GeofencingZoneStyle;
+export type GeofencingZoneStyles<T = ContrastColor> = {
+  [GZKey in GeofencingZoneKeys]: GeofencingZoneStyle<T>;
 };
 
 export interface Theme {
@@ -125,16 +133,14 @@ export interface Theme {
     primary: string;
     secondary: string;
     focus: string;
-    border: {
-      radius: {
-        small: number;
-        regular: number;
-        circle: number;
-      };
-      width: {
-        slim: number;
-        medium: number;
-      };
+    radius: {
+      small: number;
+      regular: number;
+      circle: number;
+    };
+    width: {
+      slim: number;
+      medium: number;
     };
   };
   icon: {
@@ -148,6 +154,130 @@ export interface Theme {
   geofencingZones: GeofencingZoneStyles;
 }
 
+export type ContrastColorFs = {
+  background: string;
+  foreground: {
+    primary: string;
+    secondary: string;
+    disabled: string;
+  };
+};
+
+export interface ThemeFs {
+  color: {
+    foreground: {
+      dark: ContrastColorFs['foreground'];
+      light: ContrastColorFs['foreground'];
+      dynamic: ContrastColorFs['foreground'];
+      inverse: ContrastColorFs['foreground'];
+    };
+
+    interactive: {
+      0: InteractiveColor<ContrastColorFs>;
+      1: InteractiveColor<ContrastColorFs>;
+      2: InteractiveColor<ContrastColorFs>;
+      3: InteractiveColor<ContrastColorFs>;
+      destructive: InteractiveColor<ContrastColorFs>;
+    };
+
+    transport: {
+      city: TransportColor<ContrastColorFs>;
+      region: TransportColor<ContrastColorFs>;
+      airportExpress: TransportColor<ContrastColorFs>;
+      boat: TransportColor<ContrastColorFs>;
+      train: TransportColor<ContrastColorFs>;
+      flexible: TransportColor<ContrastColorFs>;
+      scooter: TransportColor<ContrastColorFs>;
+      bike: TransportColor<ContrastColorFs>;
+      car: TransportColor<ContrastColorFs>;
+      other: TransportColor<ContrastColorFs>;
+    };
+
+    status: {
+      valid: StatusColor<ContrastColorFs>;
+      info: StatusColor<ContrastColorFs>;
+      warning: StatusColor<ContrastColorFs>;
+      error: StatusColor<ContrastColorFs>;
+    };
+
+    background: {
+      neutral: {
+        0: ContrastColorFs;
+        1: ContrastColorFs;
+        2: ContrastColorFs;
+        3: ContrastColorFs;
+      };
+      accent: {
+        0: ContrastColorFs;
+        1: ContrastColorFs;
+        2: ContrastColorFs;
+        3: ContrastColorFs;
+        4: ContrastColorFs;
+        5: ContrastColorFs;
+      };
+    };
+
+    zone: {
+      from: ContrastColorFs;
+      to: ContrastColorFs;
+    };
+
+    geofencingZone: GeofencingZoneStyles<ContrastColorFs>;
+
+    border: {
+      primary: ContrastColorFs;
+      secondary: ContrastColorFs;
+      focus: ContrastColorFs;
+    };
+  };
+
+  border: {
+    radius: {
+      small: number;
+      regular: number;
+      circle: number;
+    };
+    width: {
+      slim: number;
+      medium: number;
+    };
+  };
+
+  icon: {
+    size: {
+      xSmall: number;
+      small: number;
+      medium: number;
+      large: number;
+    }
+  };
+
+  spacing: {
+    xSmall: number;
+    small: number;
+    medium: number;
+    large: number;
+    xLarge: number;
+  };
+
+  typography: {
+    ios: {
+      font: string;
+      number: number;
+    };
+
+    android: {
+      font: string;
+      number: number;
+    };
+
+    web: {
+      font: string;
+      number: number;
+    };
+  };
+};
+
 export type Statuses = keyof Theme['status'];
 
 export enum ThemeVariant {
@@ -158,10 +288,28 @@ export enum ThemeVariant {
   Innlandet,
 }
 
-export function createThemesFor(themeVariant: ThemeVariant) {
+export interface ThemeOptions {
+  useFigmaStructure?: boolean
+}
+
+/**
+ * Get a theme object for a specific organization in the desired format.
+ * 
+ * @param themeVariant Organization
+ * @param themeOptions Set if the new Figma structure should be used
+ * @returns Theme object
+ */
+export function createThemesFor<T extends ThemeOptions>(
+  themeVariant: ThemeVariant,
+  themeOptions: T = { useFigmaStructure: false } as T
+): T['useFigmaStructure'] extends true ? Themes<ThemeFs> : Themes<Theme> {
   switch (themeVariant) {
     case ThemeVariant.AtB:
-      return AtBThemes;
+      if (themeOptions?.useFigmaStructure) {
+        return AtBThemesFs as unknown as T['useFigmaStructure'] extends true ? Themes<ThemeFs> : Themes<Theme>; 
+      } else {
+        return AtBThemes as unknown as T['useFigmaStructure'] extends true ? Themes<ThemeFs> : Themes<Theme>;;
+      }
     // case ThemeVariant.Nfk:
     //   return NfkThemes;
     // case ThemeVariant.FRAM:

--- a/packages/theme/src/theme.ts
+++ b/packages/theme/src/theme.ts
@@ -372,15 +372,15 @@ export function createThemes(
  * @param extension - Object to extend original theme. Can be nested with same keys
  * @returns new deep merged intersection themes
  */
-export function createExtendedThemes<T extends {}>(
-  themes: Themes,
+export function createExtendedThemes<T extends {}, M extends Theme | ThemeFs = Theme>(
+  themes: Themes<M>,
   extension: { light: T; dark: T },
 ): {
-  light: Themes['light'] & T,
-  dark: Themes['dark'] & T,
+  light: Themes<M>['light'] & T,
+  dark: Themes<M>['dark'] & T,
 } {
   return {
-    light: merge(themes.light, extension.light) as Themes['light'] & T,
-    dark: merge(themes.dark, extension.dark) as Themes['dark'] & T,
+    light: merge(themes.light, extension.light) as Themes<M>['light'] & T,
+    dark: merge(themes.dark, extension.dark) as Themes<M>['dark'] & T,
   };
 }

--- a/packages/theme/src/themes-fs/atb-theme/dark.ts
+++ b/packages/theme/src/themes-fs/atb-theme/dark.ts
@@ -1,0 +1,762 @@
+/**
+ * Do not edit directly, this file was auto-generated.
+ */
+
+export default {
+  color: {
+    foreground: {
+      light: {
+        primary: "#ffffff",
+        secondary: "#e1e7eb",
+        disabled: "#a9aeb1"
+      },
+      dark: {
+        primary: "#000000",
+        secondary: "#555e65",
+        disabled: "#a9aeb1"
+      },
+      dynamic: {
+        primary: "#ffffff",
+        secondary: "#e1e7eb",
+        disabled: "#a9aeb1"
+      },
+      inverse: {
+        primary: "#000000",
+        secondary: "#555e65",
+        disabled: "#a9aeb1"
+      }
+    },
+    background: {
+      neutral: {
+        0: {
+          background: "#000000",
+          foreground: {
+            primary: "#ffffff",
+            secondary: "#e1e7eb",
+            disabled: "#a9aeb1"
+          }
+        },
+        1: {
+          background: "#242b30",
+          foreground: {
+            primary: "#ffffff",
+            secondary: "#e1e7eb",
+            disabled: "#a9aeb1"
+          }
+        },
+        2: {
+          background: "#37424a",
+          foreground: {
+            primary: "#ffffff",
+            secondary: "#e1e7eb",
+            disabled: "#a9aeb1"
+          }
+        },
+        3: {
+          background: "#555e65",
+          foreground: {
+            primary: "#ffffff",
+            secondary: "#e1e7eb",
+            disabled: "#a9aeb1"
+          }
+        }
+      },
+      accent: {
+        0: {
+          background: "#37424a",
+          foreground: {
+            primary: "#ffffff",
+            secondary: "#e1e7eb",
+            disabled: "#a9aeb1"
+          }
+        },
+        1: {
+          background: "#555e65",
+          foreground: {
+            primary: "#ffffff",
+            secondary: "#e1e7eb",
+            disabled: "#a9aeb1"
+          }
+        },
+        2: {
+          background: "#d4e9ec",
+          foreground: {
+            primary: "#000000",
+            secondary: "#555e65",
+            disabled: "#a9aeb1"
+          }
+        },
+        3: {
+          background: "#007c92",
+          foreground: {
+            primary: "#ffffff",
+            secondary: "#e1e7eb",
+            disabled: "#a9aeb1"
+          }
+        },
+        4: {
+          background: "#e5e8b8",
+          foreground: {
+            primary: "#000000",
+            secondary: "#555e65",
+            disabled: "#a9aeb1"
+          }
+        },
+        5: {
+          background: "#2b343a",
+          foreground: {
+            primary: "#ffffff",
+            secondary: "#e1e7eb",
+            disabled: "#a9aeb1"
+          }
+        }
+      }
+    },
+    status: {
+      valid: {
+        primary: {
+          background: "#909a00",
+          foreground: {
+            primary: "#000000",
+            secondary: "#555e65",
+            disabled: "#a9aeb1"
+          }
+        },
+        secondary: {
+          background: "#464a00",
+          foreground: {
+            primary: "#ffffff",
+            secondary: "#e1e7eb",
+            disabled: "#a9aeb1"
+          }
+        }
+      },
+      info: {
+        primary: {
+          background: "#007c92",
+          foreground: {
+            primary: "#ffffff",
+            secondary: "#e1e7eb",
+            disabled: "#a9aeb1"
+          }
+        },
+        secondary: {
+          background: "#003943",
+          foreground: {
+            primary: "#ffffff",
+            secondary: "#e1e7eb",
+            disabled: "#a9aeb1"
+          }
+        }
+      },
+      warning: {
+        primary: {
+          background: "#e4d700",
+          foreground: {
+            primary: "#000000",
+            secondary: "#555e65",
+            disabled: "#a9aeb1"
+          }
+        },
+        secondary: {
+          background: "#1f2100",
+          foreground: {
+            primary: "#ffffff",
+            secondary: "#e1e7eb",
+            disabled: "#a9aeb1"
+          }
+        }
+      },
+      error: {
+        primary: {
+          background: "#b74166",
+          foreground: {
+            primary: "#000000",
+            secondary: "#555e65",
+            disabled: "#a9aeb1"
+          }
+        },
+        secondary: {
+          background: "#380616",
+          foreground: {
+            primary: "#ffffff",
+            secondary: "#e1e7eb",
+            disabled: "#a9aeb1"
+          }
+        }
+      }
+    },
+    interactive: {
+      0: {
+        default: {
+          background: "#007c92",
+          foreground: {
+            primary: "#ffffff",
+            secondary: "#e1e7eb",
+            disabled: "#a9aeb1"
+          }
+        },
+        hover: {
+          background: "#006678",
+          foreground: {
+            primary: "#ffffff",
+            secondary: "#e1e7eb",
+            disabled: "#a9aeb1"
+          }
+        },
+        active: {
+          background: "#a6d1d9",
+          foreground: {
+            primary: "#000000",
+            secondary: "#555e65",
+            disabled: "#a9aeb1"
+          }
+        },
+        disabled: {
+          background: "#d4e9ec",
+          foreground: {
+            primary: "#000000",
+            secondary: "#555e65",
+            disabled: "#a9aeb1"
+          }
+        },
+        outline: {
+          background: "#71d6e0",
+          foreground: {
+            primary: "#000000",
+            secondary: "#555e65",
+            disabled: "#a9aeb1"
+          }
+        },
+        destructive: {
+          background: "#d692a7",
+          foreground: {
+            primary: "#000000",
+            secondary: "#555e65",
+            disabled: "#a9aeb1"
+          }
+        }
+      },
+      1: {
+        default: {
+          background: "#555e65",
+          foreground: {
+            primary: "#ffffff",
+            secondary: "#e1e7eb",
+            disabled: "#a9aeb1"
+          }
+        },
+        hover: {
+          background: "#6f777d",
+          foreground: {
+            primary: "#000000",
+            secondary: "#555e65",
+            disabled: "#a9aeb1"
+          }
+        },
+        active: {
+          background: "#1a2024",
+          foreground: {
+            primary: "#ffffff",
+            secondary: "#e1e7eb",
+            disabled: "#a9aeb1"
+          }
+        },
+        disabled: {
+          background: "#c7cacc",
+          foreground: {
+            primary: "#000000",
+            secondary: "#555e65",
+            disabled: "#a9aeb1"
+          }
+        },
+        outline: {
+          background: "#007c92",
+          foreground: {
+            primary: "#ffffff",
+            secondary: "#e1e7eb",
+            disabled: "#a9aeb1"
+          }
+        },
+        destructive: {
+          background: "#d692a7",
+          foreground: {
+            primary: "#000000",
+            secondary: "#555e65",
+            disabled: "#a9aeb1"
+          }
+        }
+      },
+      2: {
+        default: {
+          background: "#000000",
+          foreground: {
+            primary: "#ffffff",
+            secondary: "#e1e7eb",
+            disabled: "#a9aeb1"
+          }
+        },
+        hover: {
+          background: "#002329",
+          foreground: {
+            primary: "#ffffff",
+            secondary: "#e1e7eb",
+            disabled: "#a9aeb1"
+          }
+        },
+        active: {
+          background: "#004e5c",
+          foreground: {
+            primary: "#ffffff",
+            secondary: "#e1e7eb",
+            disabled: "#a9aeb1"
+          }
+        },
+        disabled: {
+          background: "#000000",
+          foreground: {
+            primary: "#ffffff",
+            secondary: "#e1e7eb",
+            disabled: "#a9aeb1"
+          }
+        },
+        outline: {
+          background: "#007c92",
+          foreground: {
+            primary: "#ffffff",
+            secondary: "#e1e7eb",
+            disabled: "#a9aeb1"
+          }
+        },
+        destructive: {
+          background: "#d692a7",
+          foreground: {
+            primary: "#000000",
+            secondary: "#555e65",
+            disabled: "#a9aeb1"
+          }
+        }
+      },
+      3: {
+        default: {
+          background: "#004e5c",
+          foreground: {
+            primary: "#ffffff",
+            secondary: "#e1e7eb",
+            disabled: "#a9aeb1"
+          }
+        },
+        hover: {
+          background: "#003943",
+          foreground: {
+            primary: "#ffffff",
+            secondary: "#e1e7eb",
+            disabled: "#a9aeb1"
+          }
+        },
+        active: {
+          background: "#003943",
+          foreground: {
+            primary: "#ffffff",
+            secondary: "#e1e7eb",
+            disabled: "#a9aeb1"
+          }
+        },
+        disabled: {
+          background: "#555e65",
+          foreground: {
+            primary: "#ffffff",
+            secondary: "#e1e7eb",
+            disabled: "#a9aeb1"
+          }
+        },
+        outline: {
+          background: "#d4e9ec",
+          foreground: {
+            primary: "#000000",
+            secondary: "#555e65",
+            disabled: "#a9aeb1"
+          }
+        },
+        destructive: {
+          background: "#a51140",
+          foreground: {
+            primary: "#ffffff",
+            secondary: "#e1e7eb",
+            disabled: "#a9aeb1"
+          }
+        }
+      },
+      destructive: {
+        default: {
+          background: "#a51140",
+          foreground: {
+            primary: "#ffffff",
+            secondary: "#e1e7eb",
+            disabled: "#a9aeb1"
+          }
+        },
+        hover: {
+          background: "#b74166",
+          foreground: {
+            primary: "#000000",
+            secondary: "#555e65",
+            disabled: "#a9aeb1"
+          }
+        },
+        active: {
+          background: "#380616",
+          foreground: {
+            primary: "#ffffff",
+            secondary: "#e1e7eb",
+            disabled: "#a9aeb1"
+          }
+        },
+        disabled: {
+          background: "#eed2db",
+          foreground: {
+            primary: "#000000",
+            secondary: "#555e65",
+            disabled: "#a9aeb1"
+          }
+        },
+        outline: {
+          background: "#007c92",
+          foreground: {
+            primary: "#ffffff",
+            secondary: "#e1e7eb",
+            disabled: "#a9aeb1"
+          }
+        },
+        destructive: {
+          background: "#d692a7",
+          foreground: {
+            primary: "#000000",
+            secondary: "#555e65",
+            disabled: "#a9aeb1"
+          }
+        }
+      }
+    },
+    transport: {
+      city: {
+        primary: {
+          background: "#a2ad00",
+          foreground: {
+            primary: "#000000",
+            secondary: "#555e65",
+            disabled: "#a9aeb1"
+          }
+        },
+        secondary: {
+          background: "#909a00",
+          foreground: {
+            primary: "#000000",
+            secondary: "#555e65",
+            disabled: "#a9aeb1"
+          }
+        }
+      },
+      region: {
+        primary: {
+          background: "#007c92",
+          foreground: {
+            primary: "#ffffff",
+            secondary: "#e1e7eb",
+            disabled: "#a9aeb1"
+          }
+        },
+        secondary: {
+          background: "#006678",
+          foreground: {
+            primary: "#ffffff",
+            secondary: "#e1e7eb",
+            disabled: "#a9aeb1"
+          }
+        }
+      },
+      airportExpress: {
+        primary: {
+          background: "#a51140",
+          foreground: {
+            primary: "#ffffff",
+            secondary: "#e1e7eb",
+            disabled: "#a9aeb1"
+          }
+        },
+        secondary: {
+          background: "#7d0d31",
+          foreground: {
+            primary: "#ffffff",
+            secondary: "#e1e7eb",
+            disabled: "#a9aeb1"
+          }
+        }
+      },
+      flexible: {
+        primary: {
+          background: "#c75b12",
+          foreground: {
+            primary: "#000000",
+            secondary: "#555e65",
+            disabled: "#a9aeb1"
+          }
+        },
+        secondary: {
+          background: "#97450e",
+          foreground: {
+            primary: "#ffffff",
+            secondary: "#e1e7eb",
+            disabled: "#a9aeb1"
+          }
+        }
+      },
+      boat: {
+        primary: {
+          background: "#71d6e0",
+          foreground: {
+            primary: "#000000",
+            secondary: "#555e65",
+            disabled: "#a9aeb1"
+          }
+        },
+        secondary: {
+          background: "#539ca4",
+          foreground: {
+            primary: "#000000",
+            secondary: "#555e65",
+            disabled: "#a9aeb1"
+          }
+        }
+      },
+      train: {
+        primary: {
+          background: "#4b2942",
+          foreground: {
+            primary: "#ffffff",
+            secondary: "#e1e7eb",
+            disabled: "#a9aeb1"
+          }
+        },
+        secondary: {
+          background: "#2c1827",
+          foreground: {
+            primary: "#ffffff",
+            secondary: "#e1e7eb",
+            disabled: "#a9aeb1"
+          }
+        }
+      },
+      scooter: {
+        primary: {
+          background: "#464a00",
+          foreground: {
+            primary: "#ffffff",
+            secondary: "#e1e7eb",
+            disabled: "#a9aeb1"
+          }
+        },
+        secondary: {
+          background: "#323600",
+          foreground: {
+            primary: "#ffffff",
+            secondary: "#e1e7eb",
+            disabled: "#a9aeb1"
+          }
+        }
+      },
+      car: {
+        primary: {
+          background: "#5b3c53",
+          foreground: {
+            primary: "#ffffff",
+            secondary: "#e1e7eb",
+            disabled: "#a9aeb1"
+          }
+        },
+        secondary: {
+          background: "#4b2942",
+          foreground: {
+            primary: "#ffffff",
+            secondary: "#e1e7eb",
+            disabled: "#a9aeb1"
+          }
+        }
+      },
+      bike: {
+        primary: {
+          background: "#7d0d31",
+          foreground: {
+            primary: "#ffffff",
+            secondary: "#e1e7eb",
+            disabled: "#a9aeb1"
+          }
+        },
+        secondary: {
+          background: "#5c0a24",
+          foreground: {
+            primary: "#ffffff",
+            secondary: "#e1e7eb",
+            disabled: "#a9aeb1"
+          }
+        }
+      },
+      other: {
+        primary: {
+          background: "#c7cacc",
+          foreground: {
+            primary: "#000000",
+            secondary: "#555e65",
+            disabled: "#a9aeb1"
+          }
+        },
+        secondary: {
+          background: "#8d9398",
+          foreground: {
+            primary: "#000000",
+            secondary: "#555e65",
+            disabled: "#a9aeb1"
+          }
+        }
+      }
+    },
+    zone: {
+      from: {
+        background: "#a2ad00",
+        foreground: {
+          primary: "#000000",
+          secondary: "#555e65",
+          disabled: "#a9aeb1"
+        }
+      },
+      to: {
+        background: "#71d6e0",
+        foreground: {
+          primary: "#000000",
+          secondary: "#555e65",
+          disabled: "#a9aeb1"
+        }
+      }
+    },
+    geofencingZone: {
+      allowed: {
+        color: {
+          background: "#007c92",
+          foreground: {
+            primary: "#ffffff",
+            secondary: "#e1e7eb",
+            disabled: "#a9aeb1"
+          }
+        },
+        fillOpacity: 0.07999999821186066,
+        strokeOpacity: 0.6000000238418579,
+        layerIndexWeight: 1
+      },
+      slow: {
+        color: {
+          background: "#f0e973",
+          foreground: {
+            primary: "#000000",
+            secondary: "#555e65",
+            disabled: "#a9aeb1"
+          }
+        },
+        fillOpacity: 0.6000000238418579,
+        strokeOpacity: 0.800000011920929,
+        layerIndexWeight: 2
+      },
+      noParking: {
+        color: {
+          background: "#c76b89",
+          foreground: {
+            primary: "#000000",
+            secondary: "#555e65",
+            disabled: "#a9aeb1"
+          }
+        },
+        fillOpacity: 0.5,
+        strokeOpacity: 0.699999988079071,
+        layerIndexWeight: 3
+      },
+      noEntry: {
+        color: {
+          background: "#380616",
+          foreground: {
+            primary: "#ffffff",
+            secondary: "#e1e7eb",
+            disabled: "#a9aeb1"
+          }
+        },
+        fillOpacity: 0.550000011920929,
+        strokeOpacity: 0.75,
+        layerIndexWeight: 5
+      }
+    },
+    border: {
+      primary: {
+        background: "#242b30",
+        foreground: {
+          primary: "#ffffff",
+          secondary: "#e1e7eb",
+          disabled: "#a9aeb1"
+        }
+      },
+      secondary: {
+        background: "#ffffff",
+        foreground: {
+          primary: "#000000",
+          secondary: "#555e65",
+          disabled: "#a9aeb1"
+        }
+      },
+      focus: {
+        background: "#448086",
+        foreground: {
+          primary: "#000000",
+          secondary: "#555e65",
+          disabled: "#a9aeb1"
+        }
+      }
+    }
+  },
+  border: {
+    radius: {
+      small: 4,
+      regular: 8,
+      circle: 20
+    },
+    width: {
+      slim: 1,
+      medium: 2
+    }
+  },
+  typography: {
+    ios: {
+      font: "SF Pro Text",
+      number: -0.3100000023841858
+    },
+    android: {
+      font: "Roboto",
+      number: -0.5
+    },
+    web: {
+      font: "Roboto",
+      number: -0.5
+    }
+  },
+  spacing: {
+    xSmall: 4,
+    small: 8,
+    medium: 12,
+    large: 20,
+    xLarge: 24
+  },
+  icon: {
+    size: {
+      xSmall: 12,
+      small: 16,
+      medium: 20,
+      large: 26
+    }
+  }
+};

--- a/packages/theme/src/themes-fs/atb-theme/light.ts
+++ b/packages/theme/src/themes-fs/atb-theme/light.ts
@@ -1,0 +1,762 @@
+/**
+ * Do not edit directly, this file was auto-generated.
+ */
+
+export default {
+  color: {
+    foreground: {
+      light: {
+        primary: "#ffffff",
+        secondary: "#e1e7eb",
+        disabled: "#a9aeb1"
+      },
+      dark: {
+        primary: "#000000",
+        secondary: "#555e65",
+        disabled: "#a9aeb1"
+      },
+      dynamic: {
+        primary: "#000000",
+        secondary: "#555e65",
+        disabled: "#a9aeb1"
+      },
+      inverse: {
+        primary: "#ffffff",
+        secondary: "#e1e7eb",
+        disabled: "#a9aeb1"
+      }
+    },
+    background: {
+      neutral: {
+        0: {
+          background: "#ffffff",
+          foreground: {
+            primary: "#000000",
+            secondary: "#555e65",
+            disabled: "#a9aeb1"
+          }
+        },
+        1: {
+          background: "#eef3f6",
+          foreground: {
+            primary: "#000000",
+            secondary: "#555e65",
+            disabled: "#a9aeb1"
+          }
+        },
+        2: {
+          background: "#e1e7eb",
+          foreground: {
+            primary: "#000000",
+            secondary: "#555e65",
+            disabled: "#a9aeb1"
+          }
+        },
+        3: {
+          background: "#d5dce0",
+          foreground: {
+            primary: "#000000",
+            secondary: "#555e65",
+            disabled: "#a9aeb1"
+          }
+        }
+      },
+      accent: {
+        0: {
+          background: "#37424a",
+          foreground: {
+            primary: "#ffffff",
+            secondary: "#e1e7eb",
+            disabled: "#a9aeb1"
+          }
+        },
+        1: {
+          background: "#555e65",
+          foreground: {
+            primary: "#ffffff",
+            secondary: "#e1e7eb",
+            disabled: "#a9aeb1"
+          }
+        },
+        2: {
+          background: "#d4e9ec",
+          foreground: {
+            primary: "#000000",
+            secondary: "#555e65",
+            disabled: "#a9aeb1"
+          }
+        },
+        3: {
+          background: "#007c92",
+          foreground: {
+            primary: "#ffffff",
+            secondary: "#e1e7eb",
+            disabled: "#a9aeb1"
+          }
+        },
+        4: {
+          background: "#e5e8b8",
+          foreground: {
+            primary: "#000000",
+            secondary: "#555e65",
+            disabled: "#a9aeb1"
+          }
+        },
+        5: {
+          background: "#a6d1d9",
+          foreground: {
+            primary: "#000000",
+            secondary: "#555e65",
+            disabled: "#a9aeb1"
+          }
+        }
+      }
+    },
+    status: {
+      valid: {
+        primary: {
+          background: "#909a00",
+          foreground: {
+            primary: "#000000",
+            secondary: "#555e65",
+            disabled: "#a9aeb1"
+          }
+        },
+        secondary: {
+          background: "#e5e8b8",
+          foreground: {
+            primary: "#000000",
+            secondary: "#555e65",
+            disabled: "#a9aeb1"
+          }
+        }
+      },
+      info: {
+        primary: {
+          background: "#007c92",
+          foreground: {
+            primary: "#ffffff",
+            secondary: "#e1e7eb",
+            disabled: "#a9aeb1"
+          }
+        },
+        secondary: {
+          background: "#def5f8",
+          foreground: {
+            primary: "#000000",
+            secondary: "#555e65",
+            disabled: "#a9aeb1"
+          }
+        }
+      },
+      warning: {
+        primary: {
+          background: "#e4d700",
+          foreground: {
+            primary: "#000000",
+            secondary: "#555e65",
+            disabled: "#a9aeb1"
+          }
+        },
+        secondary: {
+          background: "#fbf9da",
+          foreground: {
+            primary: "#000000",
+            secondary: "#555e65",
+            disabled: "#a9aeb1"
+          }
+        }
+      },
+      error: {
+        primary: {
+          background: "#b74166",
+          foreground: {
+            primary: "#000000",
+            secondary: "#555e65",
+            disabled: "#a9aeb1"
+          }
+        },
+        secondary: {
+          background: "#f4e1e7",
+          foreground: {
+            primary: "#000000",
+            secondary: "#555e65",
+            disabled: "#a9aeb1"
+          }
+        }
+      }
+    },
+    interactive: {
+      0: {
+        default: {
+          background: "#007c92",
+          foreground: {
+            primary: "#ffffff",
+            secondary: "#e1e7eb",
+            disabled: "#a9aeb1"
+          }
+        },
+        hover: {
+          background: "#006678",
+          foreground: {
+            primary: "#ffffff",
+            secondary: "#e1e7eb",
+            disabled: "#a9aeb1"
+          }
+        },
+        active: {
+          background: "#a6d1d9",
+          foreground: {
+            primary: "#000000",
+            secondary: "#555e65",
+            disabled: "#a9aeb1"
+          }
+        },
+        disabled: {
+          background: "#d4e9ec",
+          foreground: {
+            primary: "#000000",
+            secondary: "#555e65",
+            disabled: "#a9aeb1"
+          }
+        },
+        outline: {
+          background: "#71d6e0",
+          foreground: {
+            primary: "#000000",
+            secondary: "#555e65",
+            disabled: "#a9aeb1"
+          }
+        },
+        destructive: {
+          background: "#a51140",
+          foreground: {
+            primary: "#ffffff",
+            secondary: "#e1e7eb",
+            disabled: "#a9aeb1"
+          }
+        }
+      },
+      1: {
+        default: {
+          background: "#555e65",
+          foreground: {
+            primary: "#ffffff",
+            secondary: "#e1e7eb",
+            disabled: "#a9aeb1"
+          }
+        },
+        hover: {
+          background: "#6f777d",
+          foreground: {
+            primary: "#000000",
+            secondary: "#555e65",
+            disabled: "#a9aeb1"
+          }
+        },
+        active: {
+          background: "#1a2024",
+          foreground: {
+            primary: "#ffffff",
+            secondary: "#e1e7eb",
+            disabled: "#a9aeb1"
+          }
+        },
+        disabled: {
+          background: "#c7cacc",
+          foreground: {
+            primary: "#000000",
+            secondary: "#555e65",
+            disabled: "#a9aeb1"
+          }
+        },
+        outline: {
+          background: "#007c92",
+          foreground: {
+            primary: "#ffffff",
+            secondary: "#e1e7eb",
+            disabled: "#a9aeb1"
+          }
+        },
+        destructive: {
+          background: "#a51140",
+          foreground: {
+            primary: "#ffffff",
+            secondary: "#e1e7eb",
+            disabled: "#a9aeb1"
+          }
+        }
+      },
+      2: {
+        default: {
+          background: "#ffffff",
+          foreground: {
+            primary: "#000000",
+            secondary: "#555e65",
+            disabled: "#a9aeb1"
+          }
+        },
+        hover: {
+          background: "#d4e9ec",
+          foreground: {
+            primary: "#000000",
+            secondary: "#555e65",
+            disabled: "#a9aeb1"
+          }
+        },
+        active: {
+          background: "#a6d1d9",
+          foreground: {
+            primary: "#000000",
+            secondary: "#555e65",
+            disabled: "#a9aeb1"
+          }
+        },
+        disabled: {
+          background: "#ffffff",
+          foreground: {
+            primary: "#000000",
+            secondary: "#555e65",
+            disabled: "#a9aeb1"
+          }
+        },
+        outline: {
+          background: "#007c92",
+          foreground: {
+            primary: "#ffffff",
+            secondary: "#e1e7eb",
+            disabled: "#a9aeb1"
+          }
+        },
+        destructive: {
+          background: "#a51140",
+          foreground: {
+            primary: "#ffffff",
+            secondary: "#e1e7eb",
+            disabled: "#a9aeb1"
+          }
+        }
+      },
+      3: {
+        default: {
+          background: "#d4e9ec",
+          foreground: {
+            primary: "#000000",
+            secondary: "#555e65",
+            disabled: "#a9aeb1"
+          }
+        },
+        hover: {
+          background: "#a6d1d9",
+          foreground: {
+            primary: "#000000",
+            secondary: "#555e65",
+            disabled: "#a9aeb1"
+          }
+        },
+        active: {
+          background: "#a6d1d9",
+          foreground: {
+            primary: "#000000",
+            secondary: "#555e65",
+            disabled: "#a9aeb1"
+          }
+        },
+        disabled: {
+          background: "#e1e7eb",
+          foreground: {
+            primary: "#000000",
+            secondary: "#555e65",
+            disabled: "#a9aeb1"
+          }
+        },
+        outline: {
+          background: "#004e5c",
+          foreground: {
+            primary: "#ffffff",
+            secondary: "#e1e7eb",
+            disabled: "#a9aeb1"
+          }
+        },
+        destructive: {
+          background: "#a51140",
+          foreground: {
+            primary: "#ffffff",
+            secondary: "#e1e7eb",
+            disabled: "#a9aeb1"
+          }
+        }
+      },
+      destructive: {
+        default: {
+          background: "#a51140",
+          foreground: {
+            primary: "#ffffff",
+            secondary: "#e1e7eb",
+            disabled: "#a9aeb1"
+          }
+        },
+        hover: {
+          background: "#b74166",
+          foreground: {
+            primary: "#000000",
+            secondary: "#555e65",
+            disabled: "#a9aeb1"
+          }
+        },
+        active: {
+          background: "#380616",
+          foreground: {
+            primary: "#ffffff",
+            secondary: "#e1e7eb",
+            disabled: "#a9aeb1"
+          }
+        },
+        disabled: {
+          background: "#eed2db",
+          foreground: {
+            primary: "#000000",
+            secondary: "#555e65",
+            disabled: "#a9aeb1"
+          }
+        },
+        outline: {
+          background: "#007c92",
+          foreground: {
+            primary: "#ffffff",
+            secondary: "#e1e7eb",
+            disabled: "#a9aeb1"
+          }
+        },
+        destructive: {
+          background: "#a51140",
+          foreground: {
+            primary: "#ffffff",
+            secondary: "#e1e7eb",
+            disabled: "#a9aeb1"
+          }
+        }
+      }
+    },
+    transport: {
+      city: {
+        primary: {
+          background: "#a2ad00",
+          foreground: {
+            primary: "#000000",
+            secondary: "#555e65",
+            disabled: "#a9aeb1"
+          }
+        },
+        secondary: {
+          background: "#909a00",
+          foreground: {
+            primary: "#000000",
+            secondary: "#555e65",
+            disabled: "#a9aeb1"
+          }
+        }
+      },
+      region: {
+        primary: {
+          background: "#007c92",
+          foreground: {
+            primary: "#ffffff",
+            secondary: "#e1e7eb",
+            disabled: "#a9aeb1"
+          }
+        },
+        secondary: {
+          background: "#006678",
+          foreground: {
+            primary: "#ffffff",
+            secondary: "#e1e7eb",
+            disabled: "#a9aeb1"
+          }
+        }
+      },
+      airportExpress: {
+        primary: {
+          background: "#a51140",
+          foreground: {
+            primary: "#ffffff",
+            secondary: "#e1e7eb",
+            disabled: "#a9aeb1"
+          }
+        },
+        secondary: {
+          background: "#7d0d31",
+          foreground: {
+            primary: "#ffffff",
+            secondary: "#e1e7eb",
+            disabled: "#a9aeb1"
+          }
+        }
+      },
+      flexible: {
+        primary: {
+          background: "#c75b12",
+          foreground: {
+            primary: "#000000",
+            secondary: "#555e65",
+            disabled: "#a9aeb1"
+          }
+        },
+        secondary: {
+          background: "#97450e",
+          foreground: {
+            primary: "#ffffff",
+            secondary: "#e1e7eb",
+            disabled: "#a9aeb1"
+          }
+        }
+      },
+      boat: {
+        primary: {
+          background: "#71d6e0",
+          foreground: {
+            primary: "#000000",
+            secondary: "#555e65",
+            disabled: "#a9aeb1"
+          }
+        },
+        secondary: {
+          background: "#539ca4",
+          foreground: {
+            primary: "#000000",
+            secondary: "#555e65",
+            disabled: "#a9aeb1"
+          }
+        }
+      },
+      train: {
+        primary: {
+          background: "#4b2942",
+          foreground: {
+            primary: "#ffffff",
+            secondary: "#e1e7eb",
+            disabled: "#a9aeb1"
+          }
+        },
+        secondary: {
+          background: "#2c1827",
+          foreground: {
+            primary: "#ffffff",
+            secondary: "#e1e7eb",
+            disabled: "#a9aeb1"
+          }
+        }
+      },
+      scooter: {
+        primary: {
+          background: "#464a00",
+          foreground: {
+            primary: "#ffffff",
+            secondary: "#e1e7eb",
+            disabled: "#a9aeb1"
+          }
+        },
+        secondary: {
+          background: "#323600",
+          foreground: {
+            primary: "#ffffff",
+            secondary: "#e1e7eb",
+            disabled: "#a9aeb1"
+          }
+        }
+      },
+      car: {
+        primary: {
+          background: "#5b3c53",
+          foreground: {
+            primary: "#ffffff",
+            secondary: "#e1e7eb",
+            disabled: "#a9aeb1"
+          }
+        },
+        secondary: {
+          background: "#4b2942",
+          foreground: {
+            primary: "#ffffff",
+            secondary: "#e1e7eb",
+            disabled: "#a9aeb1"
+          }
+        }
+      },
+      bike: {
+        primary: {
+          background: "#7d0d31",
+          foreground: {
+            primary: "#ffffff",
+            secondary: "#e1e7eb",
+            disabled: "#a9aeb1"
+          }
+        },
+        secondary: {
+          background: "#5c0a24",
+          foreground: {
+            primary: "#ffffff",
+            secondary: "#e1e7eb",
+            disabled: "#a9aeb1"
+          }
+        }
+      },
+      other: {
+        primary: {
+          background: "#37424a",
+          foreground: {
+            primary: "#ffffff",
+            secondary: "#e1e7eb",
+            disabled: "#a9aeb1"
+          }
+        },
+        secondary: {
+          background: "#2b343a",
+          foreground: {
+            primary: "#ffffff",
+            secondary: "#e1e7eb",
+            disabled: "#a9aeb1"
+          }
+        }
+      }
+    },
+    zone: {
+      from: {
+        background: "#a2ad00",
+        foreground: {
+          primary: "#000000",
+          secondary: "#555e65",
+          disabled: "#a9aeb1"
+        }
+      },
+      to: {
+        background: "#71d6e0",
+        foreground: {
+          primary: "#000000",
+          secondary: "#555e65",
+          disabled: "#a9aeb1"
+        }
+      }
+    },
+    geofencingZone: {
+      allowed: {
+        color: {
+          background: "#007c92",
+          foreground: {
+            primary: "#ffffff",
+            secondary: "#e1e7eb",
+            disabled: "#a9aeb1"
+          }
+        },
+        fillOpacity: 0.07500000298023224,
+        strokeOpacity: 0.5,
+        layerIndexWeight: 1
+      },
+      slow: {
+        color: {
+          background: "#f0e973",
+          foreground: {
+            primary: "#000000",
+            secondary: "#555e65",
+            disabled: "#a9aeb1"
+          }
+        },
+        fillOpacity: 0.6000000238418579,
+        strokeOpacity: 0.800000011920929,
+        layerIndexWeight: 2
+      },
+      noParking: {
+        color: {
+          background: "#c76b89",
+          foreground: {
+            primary: "#000000",
+            secondary: "#555e65",
+            disabled: "#a9aeb1"
+          }
+        },
+        fillOpacity: 0.5,
+        strokeOpacity: 0.699999988079071,
+        layerIndexWeight: 3
+      },
+      noEntry: {
+        color: {
+          background: "#380616",
+          foreground: {
+            primary: "#ffffff",
+            secondary: "#e1e7eb",
+            disabled: "#a9aeb1"
+          }
+        },
+        fillOpacity: 0.550000011920929,
+        strokeOpacity: 0.75,
+        layerIndexWeight: 5
+      }
+    },
+    border: {
+      primary: {
+        background: "#eef3f6",
+        foreground: {
+          primary: "#000000",
+          secondary: "#555e65",
+          disabled: "#a9aeb1"
+        }
+      },
+      secondary: {
+        background: "#000000",
+        foreground: {
+          primary: "#ffffff",
+          secondary: "#e1e7eb",
+          disabled: "#a9aeb1"
+        }
+      },
+      focus: {
+        background: "#007c92",
+        foreground: {
+          primary: "#ffffff",
+          secondary: "#e1e7eb",
+          disabled: "#a9aeb1"
+        }
+      }
+    }
+  },
+  border: {
+    radius: {
+      small: 4,
+      regular: 8,
+      circle: 20
+    },
+    width: {
+      slim: 1,
+      medium: 2
+    }
+  },
+  typography: {
+    ios: {
+      font: "SF Pro Text",
+      number: -0.3100000023841858
+    },
+    android: {
+      font: "Roboto",
+      number: -0.5
+    },
+    web: {
+      font: "Roboto",
+      number: -0.5
+    }
+  },
+  spacing: {
+    xSmall: 4,
+    small: 8,
+    medium: 12,
+    large: 20,
+    xLarge: 24
+  },
+  icon: {
+    size: {
+      xSmall: 12,
+      small: 16,
+      medium: 20,
+      large: 26
+    }
+  }
+};

--- a/packages/theme/src/themes-fs/atb-theme/theme.ts
+++ b/packages/theme/src/themes-fs/atb-theme/theme.ts
@@ -1,0 +1,14 @@
+/**
+ * Do not edit directly, this file was auto-generated.
+ */
+
+
+import light from "./light"
+import dark from "./dark"
+
+const themes = {
+  light,
+  dark
+}
+  
+export default themes

--- a/packages/theme/src/themes-fs/index.ts
+++ b/packages/theme/src/themes-fs/index.ts
@@ -1,0 +1,5 @@
+export {default as AtBThemesFs} from './atb-theme/theme';
+// export {default as NfkThemesFs} from './nfk-theme/theme';
+// export {default as FRAMThemesFs} from './fram-theme/theme';
+// export {default as TromsThemesFs} from './troms-theme/theme';
+// export {default as InnlandetThemesFs} from './innlandet-theme/theme';

--- a/packages/theme/src/themes/atb-theme/dark.ts
+++ b/packages/theme/src/themes/atb-theme/dark.ts
@@ -3,723 +3,390 @@
  */
 
 export default {
-  color: {
-    foreground: {
-      light: {
-        primary: "#ffffff",
-        secondary: "#e1e7eb",
-        disabled: "#a9aeb1"
-      },
-      dark: {
-        primary: "#000000",
-        secondary: "#555e65",
-        disabled: "#a9aeb1"
-      },
-      dynamic: {
-        primary: "#ffffff",
-        secondary: "#e1e7eb",
-        disabled: "#a9aeb1"
-      },
-      inverse: {
-        primary: "#000000",
-        secondary: "#555e65",
-        disabled: "#a9aeb1"
-      }
+  text: {
+    light: {
+      primary: "#ffffff",
+      secondary: "#e1e7eb",
+      disabled: "#a9aeb1"
     },
+    dark: {
+      primary: "#000000",
+      secondary: "#555e65",
+      disabled: "#a9aeb1"
+    },
+    colors: {
+      primary: "#ffffff",
+      secondary: "#e1e7eb",
+      disabled: "#a9aeb1"
+    },
+    inverse: {
+      primary: "#000000",
+      secondary: "#555e65",
+      disabled: "#a9aeb1"
+    }
+  },
+  static: {
     background: {
-      neutral: {
-        0: {
-          background: "#000000",
-          foreground: {
-            primary: "#ffffff",
-            secondary: "#e1e7eb",
-            disabled: "#a9aeb1"
-          }
-        },
-        1: {
-          background: "#242b30",
-          foreground: {
-            primary: "#ffffff",
-            secondary: "#e1e7eb",
-            disabled: "#a9aeb1"
-          }
-        },
-        2: {
-          background: "#37424a",
-          foreground: {
-            primary: "#ffffff",
-            secondary: "#e1e7eb",
-            disabled: "#a9aeb1"
-          }
-        },
-        3: {
-          background: "#555e65",
-          foreground: {
-            primary: "#ffffff",
-            secondary: "#e1e7eb",
-            disabled: "#a9aeb1"
-          }
-        }
+      background_0: {
+        background: "#000000",
+        text: "#ffffff"
       },
-      accent: {
-        0: {
-          background: "#37424a",
-          foreground: {
-            primary: "#ffffff",
-            secondary: "#e1e7eb",
-            disabled: "#a9aeb1"
-          }
-        },
-        1: {
-          background: "#555e65",
-          foreground: {
-            primary: "#ffffff",
-            secondary: "#e1e7eb",
-            disabled: "#a9aeb1"
-          }
-        },
-        2: {
-          background: "#d4e9ec",
-          foreground: {
-            primary: "#000000",
-            secondary: "#555e65",
-            disabled: "#a9aeb1"
-          }
-        },
-        3: {
-          background: "#007c92",
-          foreground: {
-            primary: "#ffffff",
-            secondary: "#e1e7eb",
-            disabled: "#a9aeb1"
-          }
-        },
-        4: {
-          background: "#e5e8b8",
-          foreground: {
-            primary: "#000000",
-            secondary: "#555e65",
-            disabled: "#a9aeb1"
-          }
-        },
-        5: {
-          background: "#2b343a",
-          foreground: {
-            primary: "#ffffff",
-            secondary: "#e1e7eb",
-            disabled: "#a9aeb1"
-          }
-        }
+      background_1: {
+        background: "#242b30",
+        text: "#ffffff"
+      },
+      background_2: {
+        background: "#37424a",
+        text: "#ffffff"
+      },
+      background_3: {
+        background: "#555e65",
+        text: "#ffffff"
+      },
+      background_accent_0: {
+        background: "#37424a",
+        text: "#ffffff"
+      },
+      background_accent_1: {
+        background: "#555e65",
+        text: "#ffffff"
+      },
+      background_accent_2: {
+        background: "#d4e9ec",
+        text: "#000000"
+      },
+      background_accent_3: {
+        background: "#007c92",
+        text: "#ffffff"
+      },
+      background_accent_4: {
+        background: "#e5e8b8",
+        text: "#000000"
+      },
+      background_accent_5: {
+        background: "#2b343a",
+        text: "#ffffff"
       }
     },
-    status: {
-      valid: {
-        primary: {
-          background: "#909a00",
-          foreground: {
-            primary: "#000000",
-            secondary: "#555e65",
-            disabled: "#a9aeb1"
-          }
-        },
-        secondary: {
-          background: "#464a00",
-          foreground: {
-            primary: "#ffffff",
-            secondary: "#e1e7eb",
-            disabled: "#a9aeb1"
-          }
-        }
-      },
-      info: {
-        primary: {
-          background: "#007c92",
-          foreground: {
-            primary: "#ffffff",
-            secondary: "#e1e7eb",
-            disabled: "#a9aeb1"
-          }
-        },
-        secondary: {
-          background: "#003943",
-          foreground: {
-            primary: "#ffffff",
-            secondary: "#e1e7eb",
-            disabled: "#a9aeb1"
-          }
-        }
-      },
-      warning: {
-        primary: {
-          background: "#e4d700",
-          foreground: {
-            primary: "#000000",
-            secondary: "#555e65",
-            disabled: "#a9aeb1"
-          }
-        },
-        secondary: {
-          background: "#1f2100",
-          foreground: {
-            primary: "#ffffff",
-            secondary: "#e1e7eb",
-            disabled: "#a9aeb1"
-          }
-        }
-      },
-      error: {
-        primary: {
-          background: "#b74166",
-          foreground: {
-            primary: "#000000",
-            secondary: "#555e65",
-            disabled: "#a9aeb1"
-          }
-        },
-        secondary: {
-          background: "#380616",
-          foreground: {
-            primary: "#ffffff",
-            secondary: "#e1e7eb",
-            disabled: "#a9aeb1"
-          }
-        }
-      }
-    },
-    interactive: {
-      0: {
-        default: {
-          background: "#007c92",
-          foreground: {
-            primary: "#ffffff",
-            secondary: "#e1e7eb",
-            disabled: "#a9aeb1"
-          }
-        },
-        hover: {
-          background: "#006678",
-          foreground: {
-            primary: "#ffffff",
-            secondary: "#e1e7eb",
-            disabled: "#a9aeb1"
-          }
-        },
-        active: {
-          background: "#a6d1d9",
-          foreground: {
-            primary: "#000000",
-            secondary: "#555e65",
-            disabled: "#a9aeb1"
-          }
-        },
-        disabled: {
-          background: "#d4e9ec",
-          foreground: {
-            primary: "#000000",
-            secondary: "#555e65",
-            disabled: "#a9aeb1"
-          }
-        },
-        outline: {
-          background: "#71d6e0",
-          foreground: {
-            primary: "#000000",
-            secondary: "#555e65",
-            disabled: "#a9aeb1"
-          }
-        },
-        destructive: {
-          background: "#d692a7",
-          foreground: {
-            primary: "#000000",
-            secondary: "#555e65",
-            disabled: "#a9aeb1"
-          }
-        }
-      },
-      1: {
-        default: {
-          background: "#555e65",
-          foreground: {
-            primary: "#ffffff",
-            secondary: "#e1e7eb",
-            disabled: "#a9aeb1"
-          }
-        },
-        hover: {
-          background: "#6f777d",
-          foreground: {
-            primary: "#000000",
-            secondary: "#555e65",
-            disabled: "#a9aeb1"
-          }
-        },
-        active: {
-          background: "#1a2024",
-          foreground: {
-            primary: "#ffffff",
-            secondary: "#e1e7eb",
-            disabled: "#a9aeb1"
-          }
-        },
-        disabled: {
-          background: "#c7cacc",
-          foreground: {
-            primary: "#000000",
-            secondary: "#555e65",
-            disabled: "#a9aeb1"
-          }
-        },
-        outline: {
-          background: "#007c92",
-          foreground: {
-            primary: "#ffffff",
-            secondary: "#e1e7eb",
-            disabled: "#a9aeb1"
-          }
-        },
-        destructive: {
-          background: "#d692a7",
-          foreground: {
-            primary: "#000000",
-            secondary: "#555e65",
-            disabled: "#a9aeb1"
-          }
-        }
-      },
-      2: {
-        default: {
-          background: "#000000",
-          foreground: {
-            primary: "#ffffff",
-            secondary: "#e1e7eb",
-            disabled: "#a9aeb1"
-          }
-        },
-        hover: {
-          background: "#002329",
-          foreground: {
-            primary: "#ffffff",
-            secondary: "#e1e7eb",
-            disabled: "#a9aeb1"
-          }
-        },
-        active: {
-          background: "#004e5c",
-          foreground: {
-            primary: "#ffffff",
-            secondary: "#e1e7eb",
-            disabled: "#a9aeb1"
-          }
-        },
-        disabled: {
-          background: "#000000",
-          foreground: {
-            primary: "#ffffff",
-            secondary: "#e1e7eb",
-            disabled: "#a9aeb1"
-          }
-        },
-        outline: {
-          background: "#007c92",
-          foreground: {
-            primary: "#ffffff",
-            secondary: "#e1e7eb",
-            disabled: "#a9aeb1"
-          }
-        },
-        destructive: {
-          background: "#d692a7",
-          foreground: {
-            primary: "#000000",
-            secondary: "#555e65",
-            disabled: "#a9aeb1"
-          }
-        }
-      },
-      3: {
-        default: {
-          background: "#004e5c",
-          foreground: {
-            primary: "#ffffff",
-            secondary: "#e1e7eb",
-            disabled: "#a9aeb1"
-          }
-        },
-        hover: {
-          background: "#003943",
-          foreground: {
-            primary: "#ffffff",
-            secondary: "#e1e7eb",
-            disabled: "#a9aeb1"
-          }
-        },
-        active: {
-          background: "#003943",
-          foreground: {
-            primary: "#ffffff",
-            secondary: "#e1e7eb",
-            disabled: "#a9aeb1"
-          }
-        },
-        disabled: {
-          background: "#555e65",
-          foreground: {
-            primary: "#ffffff",
-            secondary: "#e1e7eb",
-            disabled: "#a9aeb1"
-          }
-        },
-        outline: {
-          background: "#d4e9ec",
-          foreground: {
-            primary: "#000000",
-            secondary: "#555e65",
-            disabled: "#a9aeb1"
-          }
-        },
-        destructive: {
-          background: "#a51140",
-          foreground: {
-            primary: "#ffffff",
-            secondary: "#e1e7eb",
-            disabled: "#a9aeb1"
-          }
-        }
-      },
-      destructive: {
-        default: {
-          background: "#a51140",
-          foreground: {
-            primary: "#ffffff",
-            secondary: "#e1e7eb",
-            disabled: "#a9aeb1"
-          }
-        },
-        hover: {
-          background: "#b74166",
-          foreground: {
-            primary: "#000000",
-            secondary: "#555e65",
-            disabled: "#a9aeb1"
-          }
-        },
-        active: {
-          background: "#380616",
-          foreground: {
-            primary: "#ffffff",
-            secondary: "#e1e7eb",
-            disabled: "#a9aeb1"
-          }
-        },
-        disabled: {
-          background: "#eed2db",
-          foreground: {
-            primary: "#000000",
-            secondary: "#555e65",
-            disabled: "#a9aeb1"
-          }
-        },
-        outline: {
-          background: "#007c92",
-          foreground: {
-            primary: "#ffffff",
-            secondary: "#e1e7eb",
-            disabled: "#a9aeb1"
-          }
-        },
-        destructive: {
-          background: "#d692a7",
-          foreground: {
-            primary: "#000000",
-            secondary: "#555e65",
-            disabled: "#a9aeb1"
-          }
-        }
-      }
-    },
-    transport: {
-      city: {
-        primary: {
-          background: "#a2ad00",
-          foreground: {
-            primary: "#000000",
-            secondary: "#555e65",
-            disabled: "#a9aeb1"
-          }
-        },
-        secondary: {
-          background: "#909a00",
-          foreground: {
-            primary: "#000000",
-            secondary: "#555e65",
-            disabled: "#a9aeb1"
-          }
-        }
-      },
-      region: {
-        primary: {
-          background: "#007c92",
-          foreground: {
-            primary: "#ffffff",
-            secondary: "#e1e7eb",
-            disabled: "#a9aeb1"
-          }
-        },
-        secondary: {
-          background: "#006678",
-          foreground: {
-            primary: "#ffffff",
-            secondary: "#e1e7eb",
-            disabled: "#a9aeb1"
-          }
-        }
-      },
-      airportExpress: {
-        primary: {
-          background: "#a51140",
-          foreground: {
-            primary: "#ffffff",
-            secondary: "#e1e7eb",
-            disabled: "#a9aeb1"
-          }
-        },
-        secondary: {
-          background: "#7d0d31",
-          foreground: {
-            primary: "#ffffff",
-            secondary: "#e1e7eb",
-            disabled: "#a9aeb1"
-          }
-        }
-      },
-      flexible: {
-        primary: {
-          background: "#c75b12",
-          foreground: {
-            primary: "#000000",
-            secondary: "#555e65",
-            disabled: "#a9aeb1"
-          }
-        },
-        secondary: {
-          background: "#97450e",
-          foreground: {
-            primary: "#ffffff",
-            secondary: "#e1e7eb",
-            disabled: "#a9aeb1"
-          }
-        }
-      },
-      boat: {
-        primary: {
-          background: "#71d6e0",
-          foreground: {
-            primary: "#000000",
-            secondary: "#555e65",
-            disabled: "#a9aeb1"
-          }
-        },
-        secondary: {
-          background: "#539ca4",
-          foreground: {
-            primary: "#000000",
-            secondary: "#555e65",
-            disabled: "#a9aeb1"
-          }
-        }
-      },
-      train: {
-        primary: {
-          background: "#4b2942",
-          foreground: {
-            primary: "#ffffff",
-            secondary: "#e1e7eb",
-            disabled: "#a9aeb1"
-          }
-        },
-        secondary: {
-          background: "#2c1827",
-          foreground: {
-            primary: "#ffffff",
-            secondary: "#e1e7eb",
-            disabled: "#a9aeb1"
-          }
-        }
-      },
-      scooter: {
-        primary: {
-          background: "#464a00",
-          foreground: {
-            primary: "#ffffff",
-            secondary: "#e1e7eb",
-            disabled: "#a9aeb1"
-          }
-        },
-        secondary: {
-          background: "#323600",
-          foreground: {
-            primary: "#ffffff",
-            secondary: "#e1e7eb",
-            disabled: "#a9aeb1"
-          }
-        }
-      },
-      car: {
-        primary: {
-          background: "#5b3c53",
-          foreground: {
-            primary: "#ffffff",
-            secondary: "#e1e7eb",
-            disabled: "#a9aeb1"
-          }
-        },
-        secondary: {
-          background: "#4b2942",
-          foreground: {
-            primary: "#ffffff",
-            secondary: "#e1e7eb",
-            disabled: "#a9aeb1"
-          }
-        }
-      },
-      bike: {
-        primary: {
-          background: "#7d0d31",
-          foreground: {
-            primary: "#ffffff",
-            secondary: "#e1e7eb",
-            disabled: "#a9aeb1"
-          }
-        },
-        secondary: {
-          background: "#5c0a24",
-          foreground: {
-            primary: "#ffffff",
-            secondary: "#e1e7eb",
-            disabled: "#a9aeb1"
-          }
-        }
-      },
-      other: {
-        primary: {
-          background: "#c7cacc",
-          foreground: {
-            primary: "#000000",
-            secondary: "#555e65",
-            disabled: "#a9aeb1"
-          }
-        },
-        secondary: {
-          background: "#8d9398",
-          foreground: {
-            primary: "#000000",
-            secondary: "#555e65",
-            disabled: "#a9aeb1"
-          }
-        }
-      }
-    },
-    zone: {
+    zone_selection: {
       from: {
         background: "#a2ad00",
-        foreground: {
-          primary: "#000000",
-          secondary: "#555e65",
-          disabled: "#a9aeb1"
-        }
+        text: "#000000"
       },
       to: {
         background: "#71d6e0",
-        foreground: {
-          primary: "#000000",
-          secondary: "#555e65",
-          disabled: "#a9aeb1"
-        }
-      }
-    },
-    geofencingZone: {
-      allowed: {
-        color: {
-          background: "#007c92",
-          foreground: {
-            primary: "#ffffff",
-            secondary: "#e1e7eb",
-            disabled: "#a9aeb1"
-          }
-        },
-        fillOpacity: 0.07999999821186066,
-        strokeOpacity: 0.6000000238418579,
-        layerIndexWeight: 1
-      },
-      slow: {
-        color: {
-          background: "#f0e973",
-          foreground: {
-            primary: "#000000",
-            secondary: "#555e65",
-            disabled: "#a9aeb1"
-          }
-        },
-        fillOpacity: 0.6000000238418579,
-        strokeOpacity: 0.800000011920929,
-        layerIndexWeight: 2
-      },
-      noParking: {
-        color: {
-          background: "#c76b89",
-          foreground: {
-            primary: "#000000",
-            secondary: "#555e65",
-            disabled: "#a9aeb1"
-          }
-        },
-        fillOpacity: 0.5,
-        strokeOpacity: 0.699999988079071,
-        layerIndexWeight: 3
-      },
-      noEntry: {
-        color: {
-          background: "#380616",
-          foreground: {
-            primary: "#ffffff",
-            secondary: "#e1e7eb",
-            disabled: "#a9aeb1"
-          }
-        },
-        fillOpacity: 0.550000011920929,
-        strokeOpacity: 0.75,
-        layerIndexWeight: 5
-      }
-    },
-    border: {
-      primary: {
-        background: "#242b30",
-        foreground: {
-          primary: "#ffffff",
-          secondary: "#e1e7eb",
-          disabled: "#a9aeb1"
-        }
-      },
-      secondary: {
-        background: "#ffffff",
-        foreground: {
-          primary: "#000000",
-          secondary: "#555e65",
-          disabled: "#a9aeb1"
-        }
-      },
-      focus: {
-        background: "#448086",
-        foreground: {
-          primary: "#000000",
-          secondary: "#555e65",
-          disabled: "#a9aeb1"
-        }
+        text: "#000000"
       }
     }
   },
+  status: {
+    valid: {
+      primary: {
+        background: "#909a00",
+        text: "#000000"
+      },
+      secondary: {
+        background: "#464a00",
+        text: "#ffffff"
+      }
+    },
+    info: {
+      primary: {
+        background: "#007c92",
+        text: "#ffffff"
+      },
+      secondary: {
+        background: "#003943",
+        text: "#ffffff"
+      }
+    },
+    warning: {
+      primary: {
+        background: "#e4d700",
+        text: "#000000"
+      },
+      secondary: {
+        background: "#1f2100",
+        text: "#ffffff"
+      }
+    },
+    error: {
+      primary: {
+        background: "#b74166",
+        text: "#000000"
+      },
+      secondary: {
+        background: "#380616",
+        text: "#ffffff"
+      }
+    }
+  },
+  interactive: {
+    interactive_0: {
+      default: {
+        background: "#007c92",
+        text: "#ffffff"
+      },
+      hover: {
+        background: "#006678",
+        text: "#ffffff"
+      },
+      active: {
+        background: "#a6d1d9",
+        text: "#000000"
+      },
+      disabled: {
+        background: "#d4e9ec",
+        text: "#000000"
+      },
+      outline: {
+        background: "#71d6e0",
+        text: "#000000"
+      },
+      background: "#d692a7",
+      text: "#000000"
+    },
+    interactive_1: {
+      default: {
+        background: "#555e65",
+        text: "#ffffff"
+      },
+      hover: {
+        background: "#6f777d",
+        text: "#000000"
+      },
+      active: {
+        background: "#1a2024",
+        text: "#ffffff"
+      },
+      disabled: {
+        background: "#c7cacc",
+        text: "#000000"
+      },
+      outline: {
+        background: "#007c92",
+        text: "#ffffff"
+      },
+      background: "#d692a7",
+      text: "#000000"
+    },
+    interactive_2: {
+      default: {
+        background: "#000000",
+        text: "#ffffff"
+      },
+      hover: {
+        background: "#002329",
+        text: "#ffffff"
+      },
+      active: {
+        background: "#004e5c",
+        text: "#ffffff"
+      },
+      disabled: {
+        background: "#000000",
+        text: "#ffffff"
+      },
+      outline: {
+        background: "#007c92",
+        text: "#ffffff"
+      },
+      background: "#d692a7",
+      text: "#000000"
+    },
+    interactive_3: {
+      default: {
+        background: "#004e5c",
+        text: "#ffffff"
+      },
+      hover: {
+        background: "#003943",
+        text: "#ffffff"
+      },
+      active: {
+        background: "#003943",
+        text: "#ffffff"
+      },
+      disabled: {
+        background: "#555e65",
+        text: "#ffffff"
+      },
+      outline: {
+        background: "#d4e9ec",
+        text: "#000000"
+      },
+      background: "#a51140",
+      text: "#ffffff"
+    },
+    interactive_destructive: {
+      default: {
+        background: "#a51140",
+        text: "#ffffff"
+      },
+      hover: {
+        background: "#b74166",
+        text: "#000000"
+      },
+      active: {
+        background: "#380616",
+        text: "#ffffff"
+      },
+      disabled: {
+        background: "#eed2db",
+        text: "#000000"
+      },
+      outline: {
+        background: "#007c92",
+        text: "#ffffff"
+      },
+      background: "#d692a7",
+      text: "#000000"
+    }
+  },
+  transport: {
+    transport_city: {
+      primary: {
+        background: "#a2ad00",
+        text: "#000000"
+      },
+      secondary: {
+        background: "#909a00",
+        text: "#000000"
+      }
+    },
+    transport_region: {
+      primary: {
+        background: "#007c92",
+        text: "#ffffff"
+      },
+      secondary: {
+        background: "#006678",
+        text: "#ffffff"
+      }
+    },
+    transport_airportExpress: {
+      primary: {
+        background: "#a51140",
+        text: "#ffffff"
+      },
+      secondary: {
+        background: "#7d0d31",
+        text: "#ffffff"
+      }
+    },
+    transport_flexible: {
+      primary: {
+        background: "#c75b12",
+        text: "#000000"
+      },
+      secondary: {
+        background: "#97450e",
+        text: "#ffffff"
+      }
+    },
+    transport_boat: {
+      primary: {
+        background: "#71d6e0",
+        text: "#000000"
+      },
+      secondary: {
+        background: "#539ca4",
+        text: "#000000"
+      }
+    },
+    transport_train: {
+      primary: {
+        background: "#4b2942",
+        text: "#ffffff"
+      },
+      secondary: {
+        background: "#2c1827",
+        text: "#ffffff"
+      }
+    },
+    transport_scooter: {
+      primary: {
+        background: "#464a00",
+        text: "#ffffff"
+      },
+      secondary: {
+        background: "#323600",
+        text: "#ffffff"
+      }
+    },
+    transport_car: {
+      primary: {
+        background: "#5b3c53",
+        text: "#ffffff"
+      },
+      secondary: {
+        background: "#4b2942",
+        text: "#ffffff"
+      }
+    },
+    transport_bike: {
+      primary: {
+        background: "#7d0d31",
+        text: "#ffffff"
+      },
+      secondary: {
+        background: "#5c0a24",
+        text: "#ffffff"
+      }
+    },
+    transport_other: {
+      primary: {
+        background: "#c7cacc",
+        text: "#000000"
+      },
+      secondary: {
+        background: "#8d9398",
+        text: "#000000"
+      }
+    }
+  },
+  geofencingZones: {
+    allowed: {
+      color: {
+        background: "#007c92",
+        text: "#ffffff"
+      },
+      fillOpacity: 0.07999999821186066,
+      strokeOpacity: 0.6000000238418579,
+      layerIndexWeight: 1
+    },
+    slow: {
+      color: {
+        background: "#f0e973",
+        text: "#000000"
+      },
+      fillOpacity: 0.6000000238418579,
+      strokeOpacity: 0.800000011920929,
+      layerIndexWeight: 2
+    },
+    noParking: {
+      color: {
+        background: "#c76b89",
+        text: "#000000"
+      },
+      fillOpacity: 0.5,
+      strokeOpacity: 0.699999988079071,
+      layerIndexWeight: 3
+    },
+    noEntry: {
+      color: {
+        background: "#380616",
+        text: "#ffffff"
+      },
+      fillOpacity: 0.550000011920929,
+      strokeOpacity: 0.75,
+      layerIndexWeight: 5
+    }
+  },
   border: {
+    primary: "#242b30",
+    secondary: "#ffffff",
+    focus: "#448086",
     radius: {
       small: 4,
       medium: 8,
@@ -744,7 +411,7 @@ export default {
       number: -0.5
     }
   },
-  spacing: {
+  spacings: {
     xSmall: 4,
     small: 8,
     medium: 12,

--- a/packages/theme/src/themes/atb-theme/dark.ts
+++ b/packages/theme/src/themes/atb-theme/dark.ts
@@ -389,7 +389,7 @@ export default {
     focus: "#448086",
     radius: {
       small: 4,
-      medium: 8,
+      regular: 8,
       circle: 20
     },
     width: {

--- a/packages/theme/src/themes/atb-theme/dark.ts
+++ b/packages/theme/src/themes/atb-theme/dark.ts
@@ -264,7 +264,7 @@ export default {
         text: "#ffffff"
       }
     },
-    transport_airportExpress: {
+    transport_airport_express: {
       primary: {
         background: "#a51140",
         text: "#ffffff"

--- a/packages/theme/src/themes/atb-theme/light.ts
+++ b/packages/theme/src/themes/atb-theme/light.ts
@@ -3,723 +3,390 @@
  */
 
 export default {
-  color: {
-    foreground: {
-      light: {
-        primary: "#ffffff",
-        secondary: "#e1e7eb",
-        disabled: "#a9aeb1"
-      },
-      dark: {
-        primary: "#000000",
-        secondary: "#555e65",
-        disabled: "#a9aeb1"
-      },
-      dynamic: {
-        primary: "#000000",
-        secondary: "#555e65",
-        disabled: "#a9aeb1"
-      },
-      inverse: {
-        primary: "#ffffff",
-        secondary: "#e1e7eb",
-        disabled: "#a9aeb1"
-      }
+  text: {
+    light: {
+      primary: "#ffffff",
+      secondary: "#e1e7eb",
+      disabled: "#a9aeb1"
     },
+    dark: {
+      primary: "#000000",
+      secondary: "#555e65",
+      disabled: "#a9aeb1"
+    },
+    colors: {
+      primary: "#000000",
+      secondary: "#555e65",
+      disabled: "#a9aeb1"
+    },
+    inverse: {
+      primary: "#ffffff",
+      secondary: "#e1e7eb",
+      disabled: "#a9aeb1"
+    }
+  },
+  static: {
     background: {
-      neutral: {
-        0: {
-          background: "#ffffff",
-          foreground: {
-            primary: "#000000",
-            secondary: "#555e65",
-            disabled: "#a9aeb1"
-          }
-        },
-        1: {
-          background: "#eef3f6",
-          foreground: {
-            primary: "#000000",
-            secondary: "#555e65",
-            disabled: "#a9aeb1"
-          }
-        },
-        2: {
-          background: "#e1e7eb",
-          foreground: {
-            primary: "#000000",
-            secondary: "#555e65",
-            disabled: "#a9aeb1"
-          }
-        },
-        3: {
-          background: "#d5dce0",
-          foreground: {
-            primary: "#000000",
-            secondary: "#555e65",
-            disabled: "#a9aeb1"
-          }
-        }
+      background_0: {
+        background: "#ffffff",
+        text: "#000000"
       },
-      accent: {
-        0: {
-          background: "#37424a",
-          foreground: {
-            primary: "#ffffff",
-            secondary: "#e1e7eb",
-            disabled: "#a9aeb1"
-          }
-        },
-        1: {
-          background: "#555e65",
-          foreground: {
-            primary: "#ffffff",
-            secondary: "#e1e7eb",
-            disabled: "#a9aeb1"
-          }
-        },
-        2: {
-          background: "#d4e9ec",
-          foreground: {
-            primary: "#000000",
-            secondary: "#555e65",
-            disabled: "#a9aeb1"
-          }
-        },
-        3: {
-          background: "#007c92",
-          foreground: {
-            primary: "#ffffff",
-            secondary: "#e1e7eb",
-            disabled: "#a9aeb1"
-          }
-        },
-        4: {
-          background: "#e5e8b8",
-          foreground: {
-            primary: "#000000",
-            secondary: "#555e65",
-            disabled: "#a9aeb1"
-          }
-        },
-        5: {
-          background: "#a6d1d9",
-          foreground: {
-            primary: "#000000",
-            secondary: "#555e65",
-            disabled: "#a9aeb1"
-          }
-        }
+      background_1: {
+        background: "#eef3f6",
+        text: "#000000"
+      },
+      background_2: {
+        background: "#e1e7eb",
+        text: "#000000"
+      },
+      background_3: {
+        background: "#d5dce0",
+        text: "#000000"
+      },
+      background_accent_0: {
+        background: "#37424a",
+        text: "#ffffff"
+      },
+      background_accent_1: {
+        background: "#555e65",
+        text: "#ffffff"
+      },
+      background_accent_2: {
+        background: "#d4e9ec",
+        text: "#000000"
+      },
+      background_accent_3: {
+        background: "#007c92",
+        text: "#ffffff"
+      },
+      background_accent_4: {
+        background: "#e5e8b8",
+        text: "#000000"
+      },
+      background_accent_5: {
+        background: "#a6d1d9",
+        text: "#000000"
       }
     },
-    status: {
-      valid: {
-        primary: {
-          background: "#909a00",
-          foreground: {
-            primary: "#000000",
-            secondary: "#555e65",
-            disabled: "#a9aeb1"
-          }
-        },
-        secondary: {
-          background: "#e5e8b8",
-          foreground: {
-            primary: "#000000",
-            secondary: "#555e65",
-            disabled: "#a9aeb1"
-          }
-        }
-      },
-      info: {
-        primary: {
-          background: "#007c92",
-          foreground: {
-            primary: "#ffffff",
-            secondary: "#e1e7eb",
-            disabled: "#a9aeb1"
-          }
-        },
-        secondary: {
-          background: "#def5f8",
-          foreground: {
-            primary: "#000000",
-            secondary: "#555e65",
-            disabled: "#a9aeb1"
-          }
-        }
-      },
-      warning: {
-        primary: {
-          background: "#e4d700",
-          foreground: {
-            primary: "#000000",
-            secondary: "#555e65",
-            disabled: "#a9aeb1"
-          }
-        },
-        secondary: {
-          background: "#fbf9da",
-          foreground: {
-            primary: "#000000",
-            secondary: "#555e65",
-            disabled: "#a9aeb1"
-          }
-        }
-      },
-      error: {
-        primary: {
-          background: "#b74166",
-          foreground: {
-            primary: "#000000",
-            secondary: "#555e65",
-            disabled: "#a9aeb1"
-          }
-        },
-        secondary: {
-          background: "#f4e1e7",
-          foreground: {
-            primary: "#000000",
-            secondary: "#555e65",
-            disabled: "#a9aeb1"
-          }
-        }
-      }
-    },
-    interactive: {
-      0: {
-        default: {
-          background: "#007c92",
-          foreground: {
-            primary: "#ffffff",
-            secondary: "#e1e7eb",
-            disabled: "#a9aeb1"
-          }
-        },
-        hover: {
-          background: "#006678",
-          foreground: {
-            primary: "#ffffff",
-            secondary: "#e1e7eb",
-            disabled: "#a9aeb1"
-          }
-        },
-        active: {
-          background: "#a6d1d9",
-          foreground: {
-            primary: "#000000",
-            secondary: "#555e65",
-            disabled: "#a9aeb1"
-          }
-        },
-        disabled: {
-          background: "#d4e9ec",
-          foreground: {
-            primary: "#000000",
-            secondary: "#555e65",
-            disabled: "#a9aeb1"
-          }
-        },
-        outline: {
-          background: "#71d6e0",
-          foreground: {
-            primary: "#000000",
-            secondary: "#555e65",
-            disabled: "#a9aeb1"
-          }
-        },
-        destructive: {
-          background: "#a51140",
-          foreground: {
-            primary: "#ffffff",
-            secondary: "#e1e7eb",
-            disabled: "#a9aeb1"
-          }
-        }
-      },
-      1: {
-        default: {
-          background: "#555e65",
-          foreground: {
-            primary: "#ffffff",
-            secondary: "#e1e7eb",
-            disabled: "#a9aeb1"
-          }
-        },
-        hover: {
-          background: "#6f777d",
-          foreground: {
-            primary: "#000000",
-            secondary: "#555e65",
-            disabled: "#a9aeb1"
-          }
-        },
-        active: {
-          background: "#1a2024",
-          foreground: {
-            primary: "#ffffff",
-            secondary: "#e1e7eb",
-            disabled: "#a9aeb1"
-          }
-        },
-        disabled: {
-          background: "#c7cacc",
-          foreground: {
-            primary: "#000000",
-            secondary: "#555e65",
-            disabled: "#a9aeb1"
-          }
-        },
-        outline: {
-          background: "#007c92",
-          foreground: {
-            primary: "#ffffff",
-            secondary: "#e1e7eb",
-            disabled: "#a9aeb1"
-          }
-        },
-        destructive: {
-          background: "#a51140",
-          foreground: {
-            primary: "#ffffff",
-            secondary: "#e1e7eb",
-            disabled: "#a9aeb1"
-          }
-        }
-      },
-      2: {
-        default: {
-          background: "#ffffff",
-          foreground: {
-            primary: "#000000",
-            secondary: "#555e65",
-            disabled: "#a9aeb1"
-          }
-        },
-        hover: {
-          background: "#d4e9ec",
-          foreground: {
-            primary: "#000000",
-            secondary: "#555e65",
-            disabled: "#a9aeb1"
-          }
-        },
-        active: {
-          background: "#a6d1d9",
-          foreground: {
-            primary: "#000000",
-            secondary: "#555e65",
-            disabled: "#a9aeb1"
-          }
-        },
-        disabled: {
-          background: "#ffffff",
-          foreground: {
-            primary: "#000000",
-            secondary: "#555e65",
-            disabled: "#a9aeb1"
-          }
-        },
-        outline: {
-          background: "#007c92",
-          foreground: {
-            primary: "#ffffff",
-            secondary: "#e1e7eb",
-            disabled: "#a9aeb1"
-          }
-        },
-        destructive: {
-          background: "#a51140",
-          foreground: {
-            primary: "#ffffff",
-            secondary: "#e1e7eb",
-            disabled: "#a9aeb1"
-          }
-        }
-      },
-      3: {
-        default: {
-          background: "#d4e9ec",
-          foreground: {
-            primary: "#000000",
-            secondary: "#555e65",
-            disabled: "#a9aeb1"
-          }
-        },
-        hover: {
-          background: "#a6d1d9",
-          foreground: {
-            primary: "#000000",
-            secondary: "#555e65",
-            disabled: "#a9aeb1"
-          }
-        },
-        active: {
-          background: "#a6d1d9",
-          foreground: {
-            primary: "#000000",
-            secondary: "#555e65",
-            disabled: "#a9aeb1"
-          }
-        },
-        disabled: {
-          background: "#e1e7eb",
-          foreground: {
-            primary: "#000000",
-            secondary: "#555e65",
-            disabled: "#a9aeb1"
-          }
-        },
-        outline: {
-          background: "#004e5c",
-          foreground: {
-            primary: "#ffffff",
-            secondary: "#e1e7eb",
-            disabled: "#a9aeb1"
-          }
-        },
-        destructive: {
-          background: "#a51140",
-          foreground: {
-            primary: "#ffffff",
-            secondary: "#e1e7eb",
-            disabled: "#a9aeb1"
-          }
-        }
-      },
-      destructive: {
-        default: {
-          background: "#a51140",
-          foreground: {
-            primary: "#ffffff",
-            secondary: "#e1e7eb",
-            disabled: "#a9aeb1"
-          }
-        },
-        hover: {
-          background: "#b74166",
-          foreground: {
-            primary: "#000000",
-            secondary: "#555e65",
-            disabled: "#a9aeb1"
-          }
-        },
-        active: {
-          background: "#380616",
-          foreground: {
-            primary: "#ffffff",
-            secondary: "#e1e7eb",
-            disabled: "#a9aeb1"
-          }
-        },
-        disabled: {
-          background: "#eed2db",
-          foreground: {
-            primary: "#000000",
-            secondary: "#555e65",
-            disabled: "#a9aeb1"
-          }
-        },
-        outline: {
-          background: "#007c92",
-          foreground: {
-            primary: "#ffffff",
-            secondary: "#e1e7eb",
-            disabled: "#a9aeb1"
-          }
-        },
-        destructive: {
-          background: "#a51140",
-          foreground: {
-            primary: "#ffffff",
-            secondary: "#e1e7eb",
-            disabled: "#a9aeb1"
-          }
-        }
-      }
-    },
-    transport: {
-      city: {
-        primary: {
-          background: "#a2ad00",
-          foreground: {
-            primary: "#000000",
-            secondary: "#555e65",
-            disabled: "#a9aeb1"
-          }
-        },
-        secondary: {
-          background: "#909a00",
-          foreground: {
-            primary: "#000000",
-            secondary: "#555e65",
-            disabled: "#a9aeb1"
-          }
-        }
-      },
-      region: {
-        primary: {
-          background: "#007c92",
-          foreground: {
-            primary: "#ffffff",
-            secondary: "#e1e7eb",
-            disabled: "#a9aeb1"
-          }
-        },
-        secondary: {
-          background: "#006678",
-          foreground: {
-            primary: "#ffffff",
-            secondary: "#e1e7eb",
-            disabled: "#a9aeb1"
-          }
-        }
-      },
-      airportExpress: {
-        primary: {
-          background: "#a51140",
-          foreground: {
-            primary: "#ffffff",
-            secondary: "#e1e7eb",
-            disabled: "#a9aeb1"
-          }
-        },
-        secondary: {
-          background: "#7d0d31",
-          foreground: {
-            primary: "#ffffff",
-            secondary: "#e1e7eb",
-            disabled: "#a9aeb1"
-          }
-        }
-      },
-      flexible: {
-        primary: {
-          background: "#c75b12",
-          foreground: {
-            primary: "#000000",
-            secondary: "#555e65",
-            disabled: "#a9aeb1"
-          }
-        },
-        secondary: {
-          background: "#97450e",
-          foreground: {
-            primary: "#ffffff",
-            secondary: "#e1e7eb",
-            disabled: "#a9aeb1"
-          }
-        }
-      },
-      boat: {
-        primary: {
-          background: "#71d6e0",
-          foreground: {
-            primary: "#000000",
-            secondary: "#555e65",
-            disabled: "#a9aeb1"
-          }
-        },
-        secondary: {
-          background: "#539ca4",
-          foreground: {
-            primary: "#000000",
-            secondary: "#555e65",
-            disabled: "#a9aeb1"
-          }
-        }
-      },
-      train: {
-        primary: {
-          background: "#4b2942",
-          foreground: {
-            primary: "#ffffff",
-            secondary: "#e1e7eb",
-            disabled: "#a9aeb1"
-          }
-        },
-        secondary: {
-          background: "#2c1827",
-          foreground: {
-            primary: "#ffffff",
-            secondary: "#e1e7eb",
-            disabled: "#a9aeb1"
-          }
-        }
-      },
-      scooter: {
-        primary: {
-          background: "#464a00",
-          foreground: {
-            primary: "#ffffff",
-            secondary: "#e1e7eb",
-            disabled: "#a9aeb1"
-          }
-        },
-        secondary: {
-          background: "#323600",
-          foreground: {
-            primary: "#ffffff",
-            secondary: "#e1e7eb",
-            disabled: "#a9aeb1"
-          }
-        }
-      },
-      car: {
-        primary: {
-          background: "#5b3c53",
-          foreground: {
-            primary: "#ffffff",
-            secondary: "#e1e7eb",
-            disabled: "#a9aeb1"
-          }
-        },
-        secondary: {
-          background: "#4b2942",
-          foreground: {
-            primary: "#ffffff",
-            secondary: "#e1e7eb",
-            disabled: "#a9aeb1"
-          }
-        }
-      },
-      bike: {
-        primary: {
-          background: "#7d0d31",
-          foreground: {
-            primary: "#ffffff",
-            secondary: "#e1e7eb",
-            disabled: "#a9aeb1"
-          }
-        },
-        secondary: {
-          background: "#5c0a24",
-          foreground: {
-            primary: "#ffffff",
-            secondary: "#e1e7eb",
-            disabled: "#a9aeb1"
-          }
-        }
-      },
-      other: {
-        primary: {
-          background: "#37424a",
-          foreground: {
-            primary: "#ffffff",
-            secondary: "#e1e7eb",
-            disabled: "#a9aeb1"
-          }
-        },
-        secondary: {
-          background: "#2b343a",
-          foreground: {
-            primary: "#ffffff",
-            secondary: "#e1e7eb",
-            disabled: "#a9aeb1"
-          }
-        }
-      }
-    },
-    zone: {
+    zone_selection: {
       from: {
         background: "#a2ad00",
-        foreground: {
-          primary: "#000000",
-          secondary: "#555e65",
-          disabled: "#a9aeb1"
-        }
+        text: "#000000"
       },
       to: {
         background: "#71d6e0",
-        foreground: {
-          primary: "#000000",
-          secondary: "#555e65",
-          disabled: "#a9aeb1"
-        }
-      }
-    },
-    geofencingZone: {
-      allowed: {
-        color: {
-          background: "#007c92",
-          foreground: {
-            primary: "#ffffff",
-            secondary: "#e1e7eb",
-            disabled: "#a9aeb1"
-          }
-        },
-        fillOpacity: 0.07500000298023224,
-        strokeOpacity: 0.5,
-        layerIndexWeight: 1
-      },
-      slow: {
-        color: {
-          background: "#f0e973",
-          foreground: {
-            primary: "#000000",
-            secondary: "#555e65",
-            disabled: "#a9aeb1"
-          }
-        },
-        fillOpacity: 0.6000000238418579,
-        strokeOpacity: 0.800000011920929,
-        layerIndexWeight: 2
-      },
-      noParking: {
-        color: {
-          background: "#c76b89",
-          foreground: {
-            primary: "#000000",
-            secondary: "#555e65",
-            disabled: "#a9aeb1"
-          }
-        },
-        fillOpacity: 0.5,
-        strokeOpacity: 0.699999988079071,
-        layerIndexWeight: 3
-      },
-      noEntry: {
-        color: {
-          background: "#380616",
-          foreground: {
-            primary: "#ffffff",
-            secondary: "#e1e7eb",
-            disabled: "#a9aeb1"
-          }
-        },
-        fillOpacity: 0.550000011920929,
-        strokeOpacity: 0.75,
-        layerIndexWeight: 5
-      }
-    },
-    border: {
-      primary: {
-        background: "#eef3f6",
-        foreground: {
-          primary: "#000000",
-          secondary: "#555e65",
-          disabled: "#a9aeb1"
-        }
-      },
-      secondary: {
-        background: "#000000",
-        foreground: {
-          primary: "#ffffff",
-          secondary: "#e1e7eb",
-          disabled: "#a9aeb1"
-        }
-      },
-      focus: {
-        background: "#007c92",
-        foreground: {
-          primary: "#ffffff",
-          secondary: "#e1e7eb",
-          disabled: "#a9aeb1"
-        }
+        text: "#000000"
       }
     }
   },
+  status: {
+    valid: {
+      primary: {
+        background: "#909a00",
+        text: "#000000"
+      },
+      secondary: {
+        background: "#e5e8b8",
+        text: "#000000"
+      }
+    },
+    info: {
+      primary: {
+        background: "#007c92",
+        text: "#ffffff"
+      },
+      secondary: {
+        background: "#def5f8",
+        text: "#000000"
+      }
+    },
+    warning: {
+      primary: {
+        background: "#e4d700",
+        text: "#000000"
+      },
+      secondary: {
+        background: "#fbf9da",
+        text: "#000000"
+      }
+    },
+    error: {
+      primary: {
+        background: "#b74166",
+        text: "#000000"
+      },
+      secondary: {
+        background: "#f4e1e7",
+        text: "#000000"
+      }
+    }
+  },
+  interactive: {
+    interactive_0: {
+      default: {
+        background: "#007c92",
+        text: "#ffffff"
+      },
+      hover: {
+        background: "#006678",
+        text: "#ffffff"
+      },
+      active: {
+        background: "#a6d1d9",
+        text: "#000000"
+      },
+      disabled: {
+        background: "#d4e9ec",
+        text: "#000000"
+      },
+      outline: {
+        background: "#71d6e0",
+        text: "#000000"
+      },
+      background: "#a51140",
+      text: "#ffffff"
+    },
+    interactive_1: {
+      default: {
+        background: "#555e65",
+        text: "#ffffff"
+      },
+      hover: {
+        background: "#6f777d",
+        text: "#000000"
+      },
+      active: {
+        background: "#1a2024",
+        text: "#ffffff"
+      },
+      disabled: {
+        background: "#c7cacc",
+        text: "#000000"
+      },
+      outline: {
+        background: "#007c92",
+        text: "#ffffff"
+      },
+      background: "#a51140",
+      text: "#ffffff"
+    },
+    interactive_2: {
+      default: {
+        background: "#ffffff",
+        text: "#000000"
+      },
+      hover: {
+        background: "#d4e9ec",
+        text: "#000000"
+      },
+      active: {
+        background: "#a6d1d9",
+        text: "#000000"
+      },
+      disabled: {
+        background: "#ffffff",
+        text: "#000000"
+      },
+      outline: {
+        background: "#007c92",
+        text: "#ffffff"
+      },
+      background: "#a51140",
+      text: "#ffffff"
+    },
+    interactive_3: {
+      default: {
+        background: "#d4e9ec",
+        text: "#000000"
+      },
+      hover: {
+        background: "#a6d1d9",
+        text: "#000000"
+      },
+      active: {
+        background: "#a6d1d9",
+        text: "#000000"
+      },
+      disabled: {
+        background: "#e1e7eb",
+        text: "#000000"
+      },
+      outline: {
+        background: "#004e5c",
+        text: "#ffffff"
+      },
+      background: "#a51140",
+      text: "#ffffff"
+    },
+    interactive_destructive: {
+      default: {
+        background: "#a51140",
+        text: "#ffffff"
+      },
+      hover: {
+        background: "#b74166",
+        text: "#000000"
+      },
+      active: {
+        background: "#380616",
+        text: "#ffffff"
+      },
+      disabled: {
+        background: "#eed2db",
+        text: "#000000"
+      },
+      outline: {
+        background: "#007c92",
+        text: "#ffffff"
+      },
+      background: "#a51140",
+      text: "#ffffff"
+    }
+  },
+  transport: {
+    transport_city: {
+      primary: {
+        background: "#a2ad00",
+        text: "#000000"
+      },
+      secondary: {
+        background: "#909a00",
+        text: "#000000"
+      }
+    },
+    transport_region: {
+      primary: {
+        background: "#007c92",
+        text: "#ffffff"
+      },
+      secondary: {
+        background: "#006678",
+        text: "#ffffff"
+      }
+    },
+    transport_airportExpress: {
+      primary: {
+        background: "#a51140",
+        text: "#ffffff"
+      },
+      secondary: {
+        background: "#7d0d31",
+        text: "#ffffff"
+      }
+    },
+    transport_flexible: {
+      primary: {
+        background: "#c75b12",
+        text: "#000000"
+      },
+      secondary: {
+        background: "#97450e",
+        text: "#ffffff"
+      }
+    },
+    transport_boat: {
+      primary: {
+        background: "#71d6e0",
+        text: "#000000"
+      },
+      secondary: {
+        background: "#539ca4",
+        text: "#000000"
+      }
+    },
+    transport_train: {
+      primary: {
+        background: "#4b2942",
+        text: "#ffffff"
+      },
+      secondary: {
+        background: "#2c1827",
+        text: "#ffffff"
+      }
+    },
+    transport_scooter: {
+      primary: {
+        background: "#464a00",
+        text: "#ffffff"
+      },
+      secondary: {
+        background: "#323600",
+        text: "#ffffff"
+      }
+    },
+    transport_car: {
+      primary: {
+        background: "#5b3c53",
+        text: "#ffffff"
+      },
+      secondary: {
+        background: "#4b2942",
+        text: "#ffffff"
+      }
+    },
+    transport_bike: {
+      primary: {
+        background: "#7d0d31",
+        text: "#ffffff"
+      },
+      secondary: {
+        background: "#5c0a24",
+        text: "#ffffff"
+      }
+    },
+    transport_other: {
+      primary: {
+        background: "#37424a",
+        text: "#ffffff"
+      },
+      secondary: {
+        background: "#2b343a",
+        text: "#ffffff"
+      }
+    }
+  },
+  geofencingZones: {
+    allowed: {
+      color: {
+        background: "#007c92",
+        text: "#ffffff"
+      },
+      fillOpacity: 0.07500000298023224,
+      strokeOpacity: 0.5,
+      layerIndexWeight: 1
+    },
+    slow: {
+      color: {
+        background: "#f0e973",
+        text: "#000000"
+      },
+      fillOpacity: 0.6000000238418579,
+      strokeOpacity: 0.800000011920929,
+      layerIndexWeight: 2
+    },
+    noParking: {
+      color: {
+        background: "#c76b89",
+        text: "#000000"
+      },
+      fillOpacity: 0.5,
+      strokeOpacity: 0.699999988079071,
+      layerIndexWeight: 3
+    },
+    noEntry: {
+      color: {
+        background: "#380616",
+        text: "#ffffff"
+      },
+      fillOpacity: 0.550000011920929,
+      strokeOpacity: 0.75,
+      layerIndexWeight: 5
+    }
+  },
   border: {
+    primary: "#eef3f6",
+    secondary: "#000000",
+    focus: "#007c92",
     radius: {
       small: 4,
       medium: 8,
@@ -744,7 +411,7 @@ export default {
       number: -0.5
     }
   },
-  spacing: {
+  spacings: {
     xSmall: 4,
     small: 8,
     medium: 12,

--- a/packages/theme/src/themes/atb-theme/light.ts
+++ b/packages/theme/src/themes/atb-theme/light.ts
@@ -389,7 +389,7 @@ export default {
     focus: "#007c92",
     radius: {
       small: 4,
-      medium: 8,
+      regular: 8,
       circle: 20
     },
     width: {

--- a/packages/theme/src/themes/atb-theme/light.ts
+++ b/packages/theme/src/themes/atb-theme/light.ts
@@ -264,7 +264,7 @@ export default {
         text: "#ffffff"
       }
     },
-    transport_airportExpress: {
+    transport_airport_express: {
       primary: {
         background: "#a51140",
         text: "#ffffff"

--- a/packages/theme/src/themes/atb-theme/theme.css
+++ b/packages/theme/src/themes/atb-theme/theme.css
@@ -6,7 +6,7 @@
   --border-secondary: #000000;
   --border-focus: #007c92;
   --border-radius-small: 0.25rem;
-  --border-radius-medium: 0.5rem;
+  --border-radius-regular: 0.5rem;
   --border-radius-circle: 1.25rem;
   --border-width-slim: 0.0625rem;
   --border-width-medium: 0.125rem;
@@ -187,7 +187,7 @@
   --border-secondary: #ffffff;
   --border-focus: #448086;
   --border-radius-small: 0.25rem;
-  --border-radius-medium: 0.5rem;
+  --border-radius-regular: 0.5rem;
   --border-radius-circle: 1.25rem;
   --border-width-slim: 0.0625rem;
   --border-width-medium: 0.125rem;
@@ -368,7 +368,7 @@
   --border-secondary: #ffffff;
   --border-focus: #448086;
   --border-radius-small: 0.25rem;
-  --border-radius-medium: 0.5rem;
+  --border-radius-regular: 0.5rem;
   --border-radius-circle: 1.25rem;
   --border-width-slim: 0.0625rem;
   --border-width-medium: 0.125rem;

--- a/packages/theme/src/themes/atb-theme/theme.css
+++ b/packages/theme/src/themes/atb-theme/theme.css
@@ -2,541 +2,544 @@
 
 /* Light theme data */
 .light {
-  --border-primary: #EEF3F6;
+  --border-primary: #eef3f6;
   --border-secondary: #000000;
-  --border-focus: #007C92;
-  --border-radius-circle: 1.25rem;
-  --border-radius-regular: 0.5rem;
+  --border-focus: #007c92;
   --border-radius-small: 0.25rem;
+  --border-radius-medium: 0.5rem;
+  --border-radius-circle: 1.25rem;
   --border-width-slim: 0.0625rem;
   --border-width-medium: 0.125rem;
 
-  --spacings-xLarge: 1.5rem;
-  --spacings-large: 1.25rem;
-  --spacings-medium: 0.75rem;
-  --spacings-small: 0.5rem;
   --spacings-xSmall: 0.25rem;
+  --spacings-small: 0.5rem;
+  --spacings-medium: 0.75rem;
+  --spacings-large: 1.25rem;
+  --spacings-xLarge: 1.5rem;
 
-  --icon-size-large: 1.75rem;
-  --icon-size-normal: 1.25rem;
-  --icon-size-small: 1rem;
   --icon-size-xSmall: 0.75rem;
+  --icon-size-small: 1rem;
+  --icon-size-medium: 1.25rem;
+  --icon-size-large: 1.625rem;
 
+  --text-light-primary: #ffffff;
+  --text-light-secondary: #e1e7eb;
+  --text-light-disabled: #a9aeb1;
+  --text-dark-primary: #000000;
+  --text-dark-secondary: #555e65;
+  --text-dark-disabled: #a9aeb1;
   --text-colors-primary: #000000;
-  --text-colors-secondary: #555E65;
-  --text-colors-disabled: #A9AEB1;
+  --text-colors-secondary: #555e65;
+  --text-colors-disabled: #a9aeb1;
+  --text-inverse-primary: #ffffff;
+  --text-inverse-secondary: #e1e7eb;
+  --text-inverse-disabled: #a9aeb1;
 
-  --static-background-background_0-background: #FFFFFF;
+  --static-background-background_0-background: #ffffff;
   --static-background-background_0-text: #000000;
-  --static-background-background_1-background: #EEF3F6;
+  --static-background-background_1-background: #eef3f6;
   --static-background-background_1-text: #000000;
-  --static-background-background_2-background: #E1E7EB;
+  --static-background-background_2-background: #e1e7eb;
   --static-background-background_2-text: #000000;
-  --static-background-background_3-background: #D5DCE0;
+  --static-background-background_3-background: #d5dce0;
   --static-background-background_3-text: #000000;
-  --static-background-background_accent_0-background: #37424A;
-  --static-background-background_accent_0-text: #FFFFFF;
-  --static-background-background_accent_1-background: #555E65;
-  --static-background-background_accent_1-text: #FFFFFF;
-  --static-background-background_accent_2-background: #D4E9EC;
+  --static-background-background_accent_0-background: #37424a;
+  --static-background-background_accent_0-text: #ffffff;
+  --static-background-background_accent_1-background: #555e65;
+  --static-background-background_accent_1-text: #ffffff;
+  --static-background-background_accent_2-background: #d4e9ec;
   --static-background-background_accent_2-text: #000000;
-  --static-background-background_accent_3-background: #007C92;
-  --static-background-background_accent_3-text: #FFFFFF;
-  --static-background-background_accent_4-background: #E5E8B8;
+  --static-background-background_accent_3-background: #007c92;
+  --static-background-background_accent_3-text: #ffffff;
+  --static-background-background_accent_4-background: #e5e8b8;
   --static-background-background_accent_4-text: #000000;
-  --static-background-background_accent_5-background: #A6D1D9;
+  --static-background-background_accent_5-background: #a6d1d9;
   --static-background-background_accent_5-text: #000000;
-  --static-zone_selection-from-background: #A2AD00;
+  --static-zone_selection-from-background: #a2ad00;
   --static-zone_selection-from-text: #000000;
-  --static-zone_selection-to-background: #71D6E0;
+  --static-zone_selection-to-background: #71d6e0;
   --static-zone_selection-to-text: #000000;
 
-  --interactive-interactive_0-default-background: #007C92;
-  --interactive-interactive_0-default-text: #FFFFFF;
+  --interactive-interactive_0-default-background: #007c92;
+  --interactive-interactive_0-default-text: #ffffff;
   --interactive-interactive_0-hover-background: #006678;
-  --interactive-interactive_0-hover-text: #FFFFFF;
-  --interactive-interactive_0-active-background: #A6D1D9;
+  --interactive-interactive_0-hover-text: #ffffff;
+  --interactive-interactive_0-active-background: #a6d1d9;
   --interactive-interactive_0-active-text: #000000;
-  --interactive-interactive_0-disabled-background: #D4E9EC;
+  --interactive-interactive_0-disabled-background: #d4e9ec;
   --interactive-interactive_0-disabled-text: #000000;
-  --interactive-interactive_0-outline-background: #71D6E0;
+  --interactive-interactive_0-outline-background: #71d6e0;
   --interactive-interactive_0-outline-text: #000000;
-  --interactive-interactive_0-destructive-background: #A51140;
-  --interactive-interactive_0-destructive-text: #FFFFFF;
-  --interactive-interactive_1-default-background: #555E65;
-  --interactive-interactive_1-default-text: #FFFFFF;
-  --interactive-interactive_1-hover-background: #6F777D;
+  --interactive-interactive_0-background: #a51140;
+  --interactive-interactive_0-text: #ffffff;
+  --interactive-interactive_1-default-background: #555e65;
+  --interactive-interactive_1-default-text: #ffffff;
+  --interactive-interactive_1-hover-background: #6f777d;
   --interactive-interactive_1-hover-text: #000000;
-  --interactive-interactive_1-active-background: #1A2024;
-  --interactive-interactive_1-active-text: #FFFFFF;
-  --interactive-interactive_1-disabled-background: #C7CACC;
+  --interactive-interactive_1-active-background: #1a2024;
+  --interactive-interactive_1-active-text: #ffffff;
+  --interactive-interactive_1-disabled-background: #c7cacc;
   --interactive-interactive_1-disabled-text: #000000;
-  --interactive-interactive_1-outline-background: #007C92;
-  --interactive-interactive_1-outline-text: #FFFFFF;
-  --interactive-interactive_1-destructive-background: #A51140;
-  --interactive-interactive_1-destructive-text: #FFFFFF;
-  --interactive-interactive_2-default-background: #FFFFFF;
+  --interactive-interactive_1-outline-background: #007c92;
+  --interactive-interactive_1-outline-text: #ffffff;
+  --interactive-interactive_1-background: #a51140;
+  --interactive-interactive_1-text: #ffffff;
+  --interactive-interactive_2-default-background: #ffffff;
   --interactive-interactive_2-default-text: #000000;
-  --interactive-interactive_2-hover-background: #D4E9EC;
+  --interactive-interactive_2-hover-background: #d4e9ec;
   --interactive-interactive_2-hover-text: #000000;
-  --interactive-interactive_2-active-background: #A6D1D9;
+  --interactive-interactive_2-active-background: #a6d1d9;
   --interactive-interactive_2-active-text: #000000;
-  --interactive-interactive_2-disabled-background: #FFFFFF;
+  --interactive-interactive_2-disabled-background: #ffffff;
   --interactive-interactive_2-disabled-text: #000000;
-  --interactive-interactive_2-outline-background: #007C92;
-  --interactive-interactive_2-outline-text: #FFFFFF;
-  --interactive-interactive_2-destructive-background: #A51140;
-  --interactive-interactive_2-destructive-text: #FFFFFF;
-  --interactive-interactive_3-default-background: #D4E9EC;
+  --interactive-interactive_2-outline-background: #007c92;
+  --interactive-interactive_2-outline-text: #ffffff;
+  --interactive-interactive_2-background: #a51140;
+  --interactive-interactive_2-text: #ffffff;
+  --interactive-interactive_3-default-background: #d4e9ec;
   --interactive-interactive_3-default-text: #000000;
-  --interactive-interactive_3-hover-background: #A6D1D9;
+  --interactive-interactive_3-hover-background: #a6d1d9;
   --interactive-interactive_3-hover-text: #000000;
-  --interactive-interactive_3-active-background: #A6D1D9;
+  --interactive-interactive_3-active-background: #a6d1d9;
   --interactive-interactive_3-active-text: #000000;
-  --interactive-interactive_3-disabled-background: #E1E7EB;
+  --interactive-interactive_3-disabled-background: #e1e7eb;
   --interactive-interactive_3-disabled-text: #000000;
-  --interactive-interactive_3-outline-background: #004E5C;
-  --interactive-interactive_3-outline-text: #FFFFFF;
-  --interactive-interactive_3-destructive-background: #A51140;
-  --interactive-interactive_3-destructive-text: #FFFFFF;
-  --interactive-interactive_destructive-default-background: #A51140;
-  --interactive-interactive_destructive-default-text: #FFFFFF;
-  --interactive-interactive_destructive-hover-background: #B74166;
+  --interactive-interactive_3-outline-background: #004e5c;
+  --interactive-interactive_3-outline-text: #ffffff;
+  --interactive-interactive_3-background: #a51140;
+  --interactive-interactive_3-text: #ffffff;
+  --interactive-interactive_destructive-default-background: #a51140;
+  --interactive-interactive_destructive-default-text: #ffffff;
+  --interactive-interactive_destructive-hover-background: #b74166;
   --interactive-interactive_destructive-hover-text: #000000;
   --interactive-interactive_destructive-active-background: #380616;
-  --interactive-interactive_destructive-active-text: #FFFFFF;
-  --interactive-interactive_destructive-disabled-background: #EED2DB;
+  --interactive-interactive_destructive-active-text: #ffffff;
+  --interactive-interactive_destructive-disabled-background: #eed2db;
   --interactive-interactive_destructive-disabled-text: #000000;
-  --interactive-interactive_destructive-outline-background: #007C92;
-  --interactive-interactive_destructive-outline-text: #FFFFFF;
-  --interactive-interactive_destructive-destructive-background: #A51140;
-  --interactive-interactive_destructive-destructive-text: #FFFFFF;
+  --interactive-interactive_destructive-outline-background: #007c92;
+  --interactive-interactive_destructive-outline-text: #ffffff;
+  --interactive-interactive_destructive-background: #a51140;
+  --interactive-interactive_destructive-text: #ffffff;
 
-  --transport-transport_city-primary-background: #A2AD00;
+  --transport-transport_city-primary-background: #a2ad00;
   --transport-transport_city-primary-text: #000000;
-  --transport-transport_city-secondary-background: #909A00;
+  --transport-transport_city-secondary-background: #909a00;
   --transport-transport_city-secondary-text: #000000;
-  --transport-transport_region-primary-background: #007C92;
-  --transport-transport_region-primary-text: #FFFFFF;
+  --transport-transport_region-primary-background: #007c92;
+  --transport-transport_region-primary-text: #ffffff;
   --transport-transport_region-secondary-background: #006678;
-  --transport-transport_region-secondary-text: #FFFFFF;
-  --transport-transport_airport_express-primary-background: #A51140;
-  --transport-transport_airport_express-primary-text: #FFFFFF;
-  --transport-transport_airport_express-secondary-background: #7D0D31;
-  --transport-transport_airport_express-secondary-text: #FFFFFF;
-  --transport-transport_boat-primary-background: #71D6E0;
-  --transport-transport_boat-primary-text: #000000;
-  --transport-transport_boat-secondary-background: #539CA4;
-  --transport-transport_boat-secondary-text: #000000;
-  --transport-transport_train-primary-background: #4B2942;
-  --transport-transport_train-primary-text: #FFFFFF;
-  --transport-transport_train-secondary-background: #2C1827;
-  --transport-transport_train-secondary-text: #FFFFFF;
-  --transport-transport_airport-primary-background: #C75B12;
-  --transport-transport_airport-primary-text: #000000;
-  --transport-transport_airport-secondary-background: #97450E;
-  --transport-transport_airport-secondary-text: #FFFFFF;
-  --transport-transport_plane-primary-background: #2B343A;
-  --transport-transport_plane-primary-text: #FFFFFF;
-  --transport-transport_plane-secondary-background: #1A2024;
-  --transport-transport_plane-secondary-text: #FFFFFF;
-  --transport-transport_flexible-primary-background: #C75B12;
+  --transport-transport_region-secondary-text: #ffffff;
+  --transport-transport_airportExpress-primary-background: #a51140;
+  --transport-transport_airportExpress-primary-text: #ffffff;
+  --transport-transport_airportExpress-secondary-background: #7d0d31;
+  --transport-transport_airportExpress-secondary-text: #ffffff;
+  --transport-transport_flexible-primary-background: #c75b12;
   --transport-transport_flexible-primary-text: #000000;
-  --transport-transport_flexible-secondary-background: #97450E;
-  --transport-transport_flexible-secondary-text: #FFFFFF;
-  --transport-transport_bike-primary-background: #7D0D31;
-  --transport-transport_bike-primary-text: #FFFFFF;
-  --transport-transport_bike-secondary-background: #5C0A24;
-  --transport-transport_bike-secondary-text: #FFFFFF;
-  --transport-transport_scooter-primary-background: #464A00;
-  --transport-transport_scooter-primary-text: #FFFFFF;
+  --transport-transport_flexible-secondary-background: #97450e;
+  --transport-transport_flexible-secondary-text: #ffffff;
+  --transport-transport_boat-primary-background: #71d6e0;
+  --transport-transport_boat-primary-text: #000000;
+  --transport-transport_boat-secondary-background: #539ca4;
+  --transport-transport_boat-secondary-text: #000000;
+  --transport-transport_train-primary-background: #4b2942;
+  --transport-transport_train-primary-text: #ffffff;
+  --transport-transport_train-secondary-background: #2c1827;
+  --transport-transport_train-secondary-text: #ffffff;
+  --transport-transport_scooter-primary-background: #464a00;
+  --transport-transport_scooter-primary-text: #ffffff;
   --transport-transport_scooter-secondary-background: #323600;
-  --transport-transport_scooter-secondary-text: #FFFFFF;
-  --transport-transport_car-primary-background: #5B3C53;
-  --transport-transport_car-primary-text: #FFFFFF;
-  --transport-transport_car-secondary-background: #4B2942;
-  --transport-transport_car-secondary-text: #FFFFFF;
-  --transport-transport_other-primary-background: #555E65;
-  --transport-transport_other-primary-text: #FFFFFF;
-  --transport-transport_other-secondary-background: #2B343A;
-  --transport-transport_other-secondary-text: #FFFFFF;
+  --transport-transport_scooter-secondary-text: #ffffff;
+  --transport-transport_car-primary-background: #5b3c53;
+  --transport-transport_car-primary-text: #ffffff;
+  --transport-transport_car-secondary-background: #4b2942;
+  --transport-transport_car-secondary-text: #ffffff;
+  --transport-transport_bike-primary-background: #7d0d31;
+  --transport-transport_bike-primary-text: #ffffff;
+  --transport-transport_bike-secondary-background: #5c0a24;
+  --transport-transport_bike-secondary-text: #ffffff;
+  --transport-transport_other-primary-background: #37424a;
+  --transport-transport_other-primary-text: #ffffff;
+  --transport-transport_other-secondary-background: #2b343a;
+  --transport-transport_other-secondary-text: #ffffff;
 
-  --status-valid-primary-background: #909A00;
+  --status-valid-primary-background: #909a00;
   --status-valid-primary-text: #000000;
-  --status-valid-secondary-background: #E5E8B8;
+  --status-valid-secondary-background: #e5e8b8;
   --status-valid-secondary-text: #000000;
-  --status-info-primary-background: #007C92;
-  --status-info-primary-text: #FFFFFF;
-  --status-info-secondary-background: #DEF5F8;
+  --status-info-primary-background: #007c92;
+  --status-info-primary-text: #ffffff;
+  --status-info-secondary-background: #def5f8;
   --status-info-secondary-text: #000000;
-  --status-warning-primary-background: #E4D700;
+  --status-warning-primary-background: #e4d700;
   --status-warning-primary-text: #000000;
-  --status-warning-secondary-background: #FBF9DA;
+  --status-warning-secondary-background: #fbf9da;
   --status-warning-secondary-text: #000000;
-  --status-error-primary-background: #B74166;
+  --status-error-primary-background: #b74166;
   --status-error-primary-text: #000000;
-  --status-error-secondary-background: #F4E1E7;
+  --status-error-secondary-background: #f4e1e7;
   --status-error-secondary-text: #000000;
 }
 
 
 /* Dark theme data */
 .dark {
-  --border-primary: #242B30;
-  --border-secondary: #FFFFFF;
+  --border-primary: #242b30;
+  --border-secondary: #ffffff;
   --border-focus: #448086;
-  --border-radius-circle: 1.25rem;
-  --border-radius-regular: 0.5rem;
   --border-radius-small: 0.25rem;
+  --border-radius-medium: 0.5rem;
+  --border-radius-circle: 1.25rem;
   --border-width-slim: 0.0625rem;
   --border-width-medium: 0.125rem;
 
-  --spacings-xLarge: 1.5rem;
-  --spacings-large: 1.25rem;
-  --spacings-medium: 0.75rem;
-  --spacings-small: 0.5rem;
   --spacings-xSmall: 0.25rem;
+  --spacings-small: 0.5rem;
+  --spacings-medium: 0.75rem;
+  --spacings-large: 1.25rem;
+  --spacings-xLarge: 1.5rem;
 
-  --icon-size-large: 1.75rem;
-  --icon-size-normal: 1.25rem;
-  --icon-size-small: 1rem;
   --icon-size-xSmall: 0.75rem;
+  --icon-size-small: 1rem;
+  --icon-size-medium: 1.25rem;
+  --icon-size-large: 1.625rem;
 
-  --text-colors-primary: #FFFFFF;
-  --text-colors-secondary: #E1E7EB;
-  --text-colors-disabled: #A9AEB1;
+  --text-light-primary: #ffffff;
+  --text-light-secondary: #e1e7eb;
+  --text-light-disabled: #a9aeb1;
+  --text-dark-primary: #000000;
+  --text-dark-secondary: #555e65;
+  --text-dark-disabled: #a9aeb1;
+  --text-colors-primary: #ffffff;
+  --text-colors-secondary: #e1e7eb;
+  --text-colors-disabled: #a9aeb1;
+  --text-inverse-primary: #000000;
+  --text-inverse-secondary: #555e65;
+  --text-inverse-disabled: #a9aeb1;
 
   --static-background-background_0-background: #000000;
-  --static-background-background_0-text: #FFFFFF;
-  --static-background-background_1-background: #242B30;
-  --static-background-background_1-text: #FFFFFF;
-  --static-background-background_2-background: #37424A;
-  --static-background-background_2-text: #FFFFFF;
-  --static-background-background_3-background: #555E65;
-  --static-background-background_3-text: #FFFFFF;
-  --static-background-background_accent_0-background: #37424A;
-  --static-background-background_accent_0-text: #FFFFFF;
-  --static-background-background_accent_1-background: #555E65;
-  --static-background-background_accent_1-text: #FFFFFF;
-  --static-background-background_accent_2-background: #D4E9EC;
+  --static-background-background_0-text: #ffffff;
+  --static-background-background_1-background: #242b30;
+  --static-background-background_1-text: #ffffff;
+  --static-background-background_2-background: #37424a;
+  --static-background-background_2-text: #ffffff;
+  --static-background-background_3-background: #555e65;
+  --static-background-background_3-text: #ffffff;
+  --static-background-background_accent_0-background: #37424a;
+  --static-background-background_accent_0-text: #ffffff;
+  --static-background-background_accent_1-background: #555e65;
+  --static-background-background_accent_1-text: #ffffff;
+  --static-background-background_accent_2-background: #d4e9ec;
   --static-background-background_accent_2-text: #000000;
-  --static-background-background_accent_3-background: #007C92;
-  --static-background-background_accent_3-text: #FFFFFF;
-  --static-background-background_accent_4-background: #E5E8B8;
+  --static-background-background_accent_3-background: #007c92;
+  --static-background-background_accent_3-text: #ffffff;
+  --static-background-background_accent_4-background: #e5e8b8;
   --static-background-background_accent_4-text: #000000;
-  --static-background-background_accent_5-background: #2B343A;
-  --static-background-background_accent_5-text: #FFFFFF;
-  --static-zone_selection-from-background: #A2AD00;
+  --static-background-background_accent_5-background: #2b343a;
+  --static-background-background_accent_5-text: #ffffff;
+  --static-zone_selection-from-background: #a2ad00;
   --static-zone_selection-from-text: #000000;
-  --static-zone_selection-to-background: #71D6E0;
+  --static-zone_selection-to-background: #71d6e0;
   --static-zone_selection-to-text: #000000;
 
-  --interactive-interactive_0-default-background: #007C92;
-  --interactive-interactive_0-default-text: #FFFFFF;
+  --interactive-interactive_0-default-background: #007c92;
+  --interactive-interactive_0-default-text: #ffffff;
   --interactive-interactive_0-hover-background: #006678;
-  --interactive-interactive_0-hover-text: #FFFFFF;
-  --interactive-interactive_0-active-background: #A6D1D9;
+  --interactive-interactive_0-hover-text: #ffffff;
+  --interactive-interactive_0-active-background: #a6d1d9;
   --interactive-interactive_0-active-text: #000000;
-  --interactive-interactive_0-disabled-background: #D4E9EC;
+  --interactive-interactive_0-disabled-background: #d4e9ec;
   --interactive-interactive_0-disabled-text: #000000;
-  --interactive-interactive_0-outline-background: #71D6E0;
+  --interactive-interactive_0-outline-background: #71d6e0;
   --interactive-interactive_0-outline-text: #000000;
-  --interactive-interactive_0-destructive-background: #D691A7;
-  --interactive-interactive_0-destructive-text: #000000;
-  --interactive-interactive_1-default-background: #555E65;
-  --interactive-interactive_1-default-text: #FFFFFF;
-  --interactive-interactive_1-hover-background: #6F777D;
+  --interactive-interactive_0-background: #d692a7;
+  --interactive-interactive_0-text: #000000;
+  --interactive-interactive_1-default-background: #555e65;
+  --interactive-interactive_1-default-text: #ffffff;
+  --interactive-interactive_1-hover-background: #6f777d;
   --interactive-interactive_1-hover-text: #000000;
-  --interactive-interactive_1-active-background: #1A2024;
-  --interactive-interactive_1-active-text: #FFFFFF;
-  --interactive-interactive_1-disabled-background: #C7CACC;
+  --interactive-interactive_1-active-background: #1a2024;
+  --interactive-interactive_1-active-text: #ffffff;
+  --interactive-interactive_1-disabled-background: #c7cacc;
   --interactive-interactive_1-disabled-text: #000000;
-  --interactive-interactive_1-outline-background: #007C92;
-  --interactive-interactive_1-outline-text: #FFFFFF;
-  --interactive-interactive_1-destructive-background: #D691A7;
-  --interactive-interactive_1-destructive-text: #000000;
+  --interactive-interactive_1-outline-background: #007c92;
+  --interactive-interactive_1-outline-text: #ffffff;
+  --interactive-interactive_1-background: #d692a7;
+  --interactive-interactive_1-text: #000000;
   --interactive-interactive_2-default-background: #000000;
-  --interactive-interactive_2-default-text: #FFFFFF;
+  --interactive-interactive_2-default-text: #ffffff;
   --interactive-interactive_2-hover-background: #002329;
-  --interactive-interactive_2-hover-text: #FFFFFF;
-  --interactive-interactive_2-active-background: #004E5C;
-  --interactive-interactive_2-active-text: #FFFFFF;
+  --interactive-interactive_2-hover-text: #ffffff;
+  --interactive-interactive_2-active-background: #004e5c;
+  --interactive-interactive_2-active-text: #ffffff;
   --interactive-interactive_2-disabled-background: #000000;
-  --interactive-interactive_2-disabled-text: #FFFFFF;
-  --interactive-interactive_2-outline-background: #007C92;
-  --interactive-interactive_2-outline-text: #FFFFFF;
-  --interactive-interactive_2-destructive-background: #D691A7;
-  --interactive-interactive_2-destructive-text: #000000;
-  --interactive-interactive_3-default-background: #004E5C;
-  --interactive-interactive_3-default-text: #FFFFFF;
+  --interactive-interactive_2-disabled-text: #ffffff;
+  --interactive-interactive_2-outline-background: #007c92;
+  --interactive-interactive_2-outline-text: #ffffff;
+  --interactive-interactive_2-background: #d692a7;
+  --interactive-interactive_2-text: #000000;
+  --interactive-interactive_3-default-background: #004e5c;
+  --interactive-interactive_3-default-text: #ffffff;
   --interactive-interactive_3-hover-background: #003943;
-  --interactive-interactive_3-hover-text: #FFFFFF;
+  --interactive-interactive_3-hover-text: #ffffff;
   --interactive-interactive_3-active-background: #003943;
-  --interactive-interactive_3-active-text: #FFFFFF;
-  --interactive-interactive_3-disabled-background: #555E65;
-  --interactive-interactive_3-disabled-text: #FFFFFF;
-  --interactive-interactive_3-outline-background: #D4E9EC;
+  --interactive-interactive_3-active-text: #ffffff;
+  --interactive-interactive_3-disabled-background: #555e65;
+  --interactive-interactive_3-disabled-text: #ffffff;
+  --interactive-interactive_3-outline-background: #d4e9ec;
   --interactive-interactive_3-outline-text: #000000;
-  --interactive-interactive_3-destructive-background: #A51140;
-  --interactive-interactive_3-destructive-text: #FFFFFF;
-  --interactive-interactive_destructive-default-background: #A51140;
-  --interactive-interactive_destructive-default-text: #FFFFFF;
-  --interactive-interactive_destructive-hover-background: #B74166;
+  --interactive-interactive_3-background: #a51140;
+  --interactive-interactive_3-text: #ffffff;
+  --interactive-interactive_destructive-default-background: #a51140;
+  --interactive-interactive_destructive-default-text: #ffffff;
+  --interactive-interactive_destructive-hover-background: #b74166;
   --interactive-interactive_destructive-hover-text: #000000;
   --interactive-interactive_destructive-active-background: #380616;
-  --interactive-interactive_destructive-active-text: #FFFFFF;
-  --interactive-interactive_destructive-disabled-background: #EED2DB;
+  --interactive-interactive_destructive-active-text: #ffffff;
+  --interactive-interactive_destructive-disabled-background: #eed2db;
   --interactive-interactive_destructive-disabled-text: #000000;
-  --interactive-interactive_destructive-outline-background: #007C92;
-  --interactive-interactive_destructive-outline-text: #FFFFFF;
-  --interactive-interactive_destructive-destructive-background: #D691A7;
-  --interactive-interactive_destructive-destructive-text: #000000;
+  --interactive-interactive_destructive-outline-background: #007c92;
+  --interactive-interactive_destructive-outline-text: #ffffff;
+  --interactive-interactive_destructive-background: #d692a7;
+  --interactive-interactive_destructive-text: #000000;
 
-  --transport-transport_city-primary-background: #A2AD00;
+  --transport-transport_city-primary-background: #a2ad00;
   --transport-transport_city-primary-text: #000000;
-  --transport-transport_city-secondary-background: #909A00;
+  --transport-transport_city-secondary-background: #909a00;
   --transport-transport_city-secondary-text: #000000;
-  --transport-transport_region-primary-background: #007C92;
-  --transport-transport_region-primary-text: #FFFFFF;
+  --transport-transport_region-primary-background: #007c92;
+  --transport-transport_region-primary-text: #ffffff;
   --transport-transport_region-secondary-background: #006678;
-  --transport-transport_region-secondary-text: #FFFFFF;
-  --transport-transport_airport_express-primary-background: #A51140;
-  --transport-transport_airport_express-primary-text: #FFFFFF;
-  --transport-transport_airport_express-secondary-background: #7D0D31;
-  --transport-transport_airport_express-secondary-text: #FFFFFF;
-  --transport-transport_boat-primary-background: #71D6E0;
-  --transport-transport_boat-primary-text: #000000;
-  --transport-transport_boat-secondary-background: #539CA4;
-  --transport-transport_boat-secondary-text: #000000;
-  --transport-transport_train-primary-background: #4B2942;
-  --transport-transport_train-primary-text: #FFFFFF;
-  --transport-transport_train-secondary-background: #2C1827;
-  --transport-transport_train-secondary-text: #FFFFFF;
-  --transport-transport_airport-primary-background: #C75B12;
-  --transport-transport_airport-primary-text: #000000;
-  --transport-transport_airport-secondary-background: #97450E;
-  --transport-transport_airport-secondary-text: #FFFFFF;
-  --transport-transport_plane-primary-background: #2B343A;
-  --transport-transport_plane-primary-text: #FFFFFF;
-  --transport-transport_plane-secondary-background: #1A2024;
-  --transport-transport_plane-secondary-text: #FFFFFF;
-  --transport-transport_flexible-primary-background: #C75B12;
+  --transport-transport_region-secondary-text: #ffffff;
+  --transport-transport_airportExpress-primary-background: #a51140;
+  --transport-transport_airportExpress-primary-text: #ffffff;
+  --transport-transport_airportExpress-secondary-background: #7d0d31;
+  --transport-transport_airportExpress-secondary-text: #ffffff;
+  --transport-transport_flexible-primary-background: #c75b12;
   --transport-transport_flexible-primary-text: #000000;
-  --transport-transport_flexible-secondary-background: #97450E;
-  --transport-transport_flexible-secondary-text: #FFFFFF;
-  --transport-transport_bike-primary-background: #A51140;
-  --transport-transport_bike-primary-text: #FFFFFF;
-  --transport-transport_bike-secondary-background: #5C0A24;
-  --transport-transport_bike-secondary-text: #FFFFFF;
-  --transport-transport_scooter-primary-background: #5B6100;
-  --transport-transport_scooter-primary-text: #FFFFFF;
+  --transport-transport_flexible-secondary-background: #97450e;
+  --transport-transport_flexible-secondary-text: #ffffff;
+  --transport-transport_boat-primary-background: #71d6e0;
+  --transport-transport_boat-primary-text: #000000;
+  --transport-transport_boat-secondary-background: #539ca4;
+  --transport-transport_boat-secondary-text: #000000;
+  --transport-transport_train-primary-background: #4b2942;
+  --transport-transport_train-primary-text: #ffffff;
+  --transport-transport_train-secondary-background: #2c1827;
+  --transport-transport_train-secondary-text: #ffffff;
+  --transport-transport_scooter-primary-background: #464a00;
+  --transport-transport_scooter-primary-text: #ffffff;
   --transport-transport_scooter-secondary-background: #323600;
-  --transport-transport_scooter-secondary-text: #FFFFFF;
-  --transport-transport_car-primary-background: #6F5468;
-  --transport-transport_car-primary-text: #FFFFFF;
-  --transport-transport_car-secondary-background: #4B2942;
-  --transport-transport_car-secondary-text: #FFFFFF;
-  --transport-transport_other-primary-background: #C7CACC;
+  --transport-transport_scooter-secondary-text: #ffffff;
+  --transport-transport_car-primary-background: #5b3c53;
+  --transport-transport_car-primary-text: #ffffff;
+  --transport-transport_car-secondary-background: #4b2942;
+  --transport-transport_car-secondary-text: #ffffff;
+  --transport-transport_bike-primary-background: #7d0d31;
+  --transport-transport_bike-primary-text: #ffffff;
+  --transport-transport_bike-secondary-background: #5c0a24;
+  --transport-transport_bike-secondary-text: #ffffff;
+  --transport-transport_other-primary-background: #c7cacc;
   --transport-transport_other-primary-text: #000000;
-  --transport-transport_other-secondary-background: #8D9398;
+  --transport-transport_other-secondary-background: #8d9398;
   --transport-transport_other-secondary-text: #000000;
 
-  --status-valid-primary-background: #909A00;
+  --status-valid-primary-background: #909a00;
   --status-valid-primary-text: #000000;
-  --status-valid-secondary-background: #464A00;
-  --status-valid-secondary-text: #FFFFFF;
-  --status-info-primary-background: #007C92;
-  --status-info-primary-text: #FFFFFF;
+  --status-valid-secondary-background: #464a00;
+  --status-valid-secondary-text: #ffffff;
+  --status-info-primary-background: #007c92;
+  --status-info-primary-text: #ffffff;
   --status-info-secondary-background: #003943;
-  --status-info-secondary-text: #FFFFFF;
-  --status-warning-primary-background: #E4D700;
+  --status-info-secondary-text: #ffffff;
+  --status-warning-primary-background: #e4d700;
   --status-warning-primary-text: #000000;
-  --status-warning-secondary-background: #1F2100;
-  --status-warning-secondary-text: #FFFFFF;
-  --status-error-primary-background: #B74166;
+  --status-warning-secondary-background: #1f2100;
+  --status-warning-secondary-text: #ffffff;
+  --status-error-primary-background: #b74166;
   --status-error-primary-text: #000000;
   --status-error-secondary-background: #380616;
-  --status-error-secondary-text: #FFFFFF;
+  --status-error-secondary-text: #ffffff;
 }
 
 
 @media (prefers-color-scheme: dark) {
   .light:not(.override-light) {
-  --border-primary: #242B30;
-  --border-secondary: #FFFFFF;
+  --border-primary: #242b30;
+  --border-secondary: #ffffff;
   --border-focus: #448086;
-  --border-radius-circle: 1.25rem;
-  --border-radius-regular: 0.5rem;
   --border-radius-small: 0.25rem;
+  --border-radius-medium: 0.5rem;
+  --border-radius-circle: 1.25rem;
   --border-width-slim: 0.0625rem;
   --border-width-medium: 0.125rem;
 
-  --spacings-xLarge: 1.5rem;
-  --spacings-large: 1.25rem;
-  --spacings-medium: 0.75rem;
-  --spacings-small: 0.5rem;
   --spacings-xSmall: 0.25rem;
+  --spacings-small: 0.5rem;
+  --spacings-medium: 0.75rem;
+  --spacings-large: 1.25rem;
+  --spacings-xLarge: 1.5rem;
 
-  --icon-size-large: 1.75rem;
-  --icon-size-normal: 1.25rem;
-  --icon-size-small: 1rem;
   --icon-size-xSmall: 0.75rem;
+  --icon-size-small: 1rem;
+  --icon-size-medium: 1.25rem;
+  --icon-size-large: 1.625rem;
 
-  --text-colors-primary: #FFFFFF;
-  --text-colors-secondary: #E1E7EB;
-  --text-colors-disabled: #A9AEB1;
+  --text-light-primary: #ffffff;
+  --text-light-secondary: #e1e7eb;
+  --text-light-disabled: #a9aeb1;
+  --text-dark-primary: #000000;
+  --text-dark-secondary: #555e65;
+  --text-dark-disabled: #a9aeb1;
+  --text-colors-primary: #ffffff;
+  --text-colors-secondary: #e1e7eb;
+  --text-colors-disabled: #a9aeb1;
+  --text-inverse-primary: #000000;
+  --text-inverse-secondary: #555e65;
+  --text-inverse-disabled: #a9aeb1;
 
   --static-background-background_0-background: #000000;
-  --static-background-background_0-text: #FFFFFF;
-  --static-background-background_1-background: #242B30;
-  --static-background-background_1-text: #FFFFFF;
-  --static-background-background_2-background: #37424A;
-  --static-background-background_2-text: #FFFFFF;
-  --static-background-background_3-background: #555E65;
-  --static-background-background_3-text: #FFFFFF;
-  --static-background-background_accent_0-background: #37424A;
-  --static-background-background_accent_0-text: #FFFFFF;
-  --static-background-background_accent_1-background: #555E65;
-  --static-background-background_accent_1-text: #FFFFFF;
-  --static-background-background_accent_2-background: #D4E9EC;
+  --static-background-background_0-text: #ffffff;
+  --static-background-background_1-background: #242b30;
+  --static-background-background_1-text: #ffffff;
+  --static-background-background_2-background: #37424a;
+  --static-background-background_2-text: #ffffff;
+  --static-background-background_3-background: #555e65;
+  --static-background-background_3-text: #ffffff;
+  --static-background-background_accent_0-background: #37424a;
+  --static-background-background_accent_0-text: #ffffff;
+  --static-background-background_accent_1-background: #555e65;
+  --static-background-background_accent_1-text: #ffffff;
+  --static-background-background_accent_2-background: #d4e9ec;
   --static-background-background_accent_2-text: #000000;
-  --static-background-background_accent_3-background: #007C92;
-  --static-background-background_accent_3-text: #FFFFFF;
-  --static-background-background_accent_4-background: #E5E8B8;
+  --static-background-background_accent_3-background: #007c92;
+  --static-background-background_accent_3-text: #ffffff;
+  --static-background-background_accent_4-background: #e5e8b8;
   --static-background-background_accent_4-text: #000000;
-  --static-background-background_accent_5-background: #2B343A;
-  --static-background-background_accent_5-text: #FFFFFF;
-  --static-zone_selection-from-background: #A2AD00;
+  --static-background-background_accent_5-background: #2b343a;
+  --static-background-background_accent_5-text: #ffffff;
+  --static-zone_selection-from-background: #a2ad00;
   --static-zone_selection-from-text: #000000;
-  --static-zone_selection-to-background: #71D6E0;
+  --static-zone_selection-to-background: #71d6e0;
   --static-zone_selection-to-text: #000000;
 
-  --interactive-interactive_0-default-background: #007C92;
-  --interactive-interactive_0-default-text: #FFFFFF;
+  --interactive-interactive_0-default-background: #007c92;
+  --interactive-interactive_0-default-text: #ffffff;
   --interactive-interactive_0-hover-background: #006678;
-  --interactive-interactive_0-hover-text: #FFFFFF;
-  --interactive-interactive_0-active-background: #A6D1D9;
+  --interactive-interactive_0-hover-text: #ffffff;
+  --interactive-interactive_0-active-background: #a6d1d9;
   --interactive-interactive_0-active-text: #000000;
-  --interactive-interactive_0-disabled-background: #D4E9EC;
+  --interactive-interactive_0-disabled-background: #d4e9ec;
   --interactive-interactive_0-disabled-text: #000000;
-  --interactive-interactive_0-outline-background: #71D6E0;
+  --interactive-interactive_0-outline-background: #71d6e0;
   --interactive-interactive_0-outline-text: #000000;
-  --interactive-interactive_0-destructive-background: #D691A7;
-  --interactive-interactive_0-destructive-text: #000000;
-  --interactive-interactive_1-default-background: #555E65;
-  --interactive-interactive_1-default-text: #FFFFFF;
-  --interactive-interactive_1-hover-background: #6F777D;
+  --interactive-interactive_0-background: #d692a7;
+  --interactive-interactive_0-text: #000000;
+  --interactive-interactive_1-default-background: #555e65;
+  --interactive-interactive_1-default-text: #ffffff;
+  --interactive-interactive_1-hover-background: #6f777d;
   --interactive-interactive_1-hover-text: #000000;
-  --interactive-interactive_1-active-background: #1A2024;
-  --interactive-interactive_1-active-text: #FFFFFF;
-  --interactive-interactive_1-disabled-background: #C7CACC;
+  --interactive-interactive_1-active-background: #1a2024;
+  --interactive-interactive_1-active-text: #ffffff;
+  --interactive-interactive_1-disabled-background: #c7cacc;
   --interactive-interactive_1-disabled-text: #000000;
-  --interactive-interactive_1-outline-background: #007C92;
-  --interactive-interactive_1-outline-text: #FFFFFF;
-  --interactive-interactive_1-destructive-background: #D691A7;
-  --interactive-interactive_1-destructive-text: #000000;
+  --interactive-interactive_1-outline-background: #007c92;
+  --interactive-interactive_1-outline-text: #ffffff;
+  --interactive-interactive_1-background: #d692a7;
+  --interactive-interactive_1-text: #000000;
   --interactive-interactive_2-default-background: #000000;
-  --interactive-interactive_2-default-text: #FFFFFF;
+  --interactive-interactive_2-default-text: #ffffff;
   --interactive-interactive_2-hover-background: #002329;
-  --interactive-interactive_2-hover-text: #FFFFFF;
-  --interactive-interactive_2-active-background: #004E5C;
-  --interactive-interactive_2-active-text: #FFFFFF;
+  --interactive-interactive_2-hover-text: #ffffff;
+  --interactive-interactive_2-active-background: #004e5c;
+  --interactive-interactive_2-active-text: #ffffff;
   --interactive-interactive_2-disabled-background: #000000;
-  --interactive-interactive_2-disabled-text: #FFFFFF;
-  --interactive-interactive_2-outline-background: #007C92;
-  --interactive-interactive_2-outline-text: #FFFFFF;
-  --interactive-interactive_2-destructive-background: #D691A7;
-  --interactive-interactive_2-destructive-text: #000000;
-  --interactive-interactive_3-default-background: #004E5C;
-  --interactive-interactive_3-default-text: #FFFFFF;
+  --interactive-interactive_2-disabled-text: #ffffff;
+  --interactive-interactive_2-outline-background: #007c92;
+  --interactive-interactive_2-outline-text: #ffffff;
+  --interactive-interactive_2-background: #d692a7;
+  --interactive-interactive_2-text: #000000;
+  --interactive-interactive_3-default-background: #004e5c;
+  --interactive-interactive_3-default-text: #ffffff;
   --interactive-interactive_3-hover-background: #003943;
-  --interactive-interactive_3-hover-text: #FFFFFF;
+  --interactive-interactive_3-hover-text: #ffffff;
   --interactive-interactive_3-active-background: #003943;
-  --interactive-interactive_3-active-text: #FFFFFF;
-  --interactive-interactive_3-disabled-background: #555E65;
-  --interactive-interactive_3-disabled-text: #FFFFFF;
-  --interactive-interactive_3-outline-background: #D4E9EC;
+  --interactive-interactive_3-active-text: #ffffff;
+  --interactive-interactive_3-disabled-background: #555e65;
+  --interactive-interactive_3-disabled-text: #ffffff;
+  --interactive-interactive_3-outline-background: #d4e9ec;
   --interactive-interactive_3-outline-text: #000000;
-  --interactive-interactive_3-destructive-background: #A51140;
-  --interactive-interactive_3-destructive-text: #FFFFFF;
-  --interactive-interactive_destructive-default-background: #A51140;
-  --interactive-interactive_destructive-default-text: #FFFFFF;
-  --interactive-interactive_destructive-hover-background: #B74166;
+  --interactive-interactive_3-background: #a51140;
+  --interactive-interactive_3-text: #ffffff;
+  --interactive-interactive_destructive-default-background: #a51140;
+  --interactive-interactive_destructive-default-text: #ffffff;
+  --interactive-interactive_destructive-hover-background: #b74166;
   --interactive-interactive_destructive-hover-text: #000000;
   --interactive-interactive_destructive-active-background: #380616;
-  --interactive-interactive_destructive-active-text: #FFFFFF;
-  --interactive-interactive_destructive-disabled-background: #EED2DB;
+  --interactive-interactive_destructive-active-text: #ffffff;
+  --interactive-interactive_destructive-disabled-background: #eed2db;
   --interactive-interactive_destructive-disabled-text: #000000;
-  --interactive-interactive_destructive-outline-background: #007C92;
-  --interactive-interactive_destructive-outline-text: #FFFFFF;
-  --interactive-interactive_destructive-destructive-background: #D691A7;
-  --interactive-interactive_destructive-destructive-text: #000000;
+  --interactive-interactive_destructive-outline-background: #007c92;
+  --interactive-interactive_destructive-outline-text: #ffffff;
+  --interactive-interactive_destructive-background: #d692a7;
+  --interactive-interactive_destructive-text: #000000;
 
-  --transport-transport_city-primary-background: #A2AD00;
+  --transport-transport_city-primary-background: #a2ad00;
   --transport-transport_city-primary-text: #000000;
-  --transport-transport_city-secondary-background: #909A00;
+  --transport-transport_city-secondary-background: #909a00;
   --transport-transport_city-secondary-text: #000000;
-  --transport-transport_region-primary-background: #007C92;
-  --transport-transport_region-primary-text: #FFFFFF;
+  --transport-transport_region-primary-background: #007c92;
+  --transport-transport_region-primary-text: #ffffff;
   --transport-transport_region-secondary-background: #006678;
-  --transport-transport_region-secondary-text: #FFFFFF;
-  --transport-transport_airport_express-primary-background: #A51140;
-  --transport-transport_airport_express-primary-text: #FFFFFF;
-  --transport-transport_airport_express-secondary-background: #7D0D31;
-  --transport-transport_airport_express-secondary-text: #FFFFFF;
-  --transport-transport_boat-primary-background: #71D6E0;
-  --transport-transport_boat-primary-text: #000000;
-  --transport-transport_boat-secondary-background: #539CA4;
-  --transport-transport_boat-secondary-text: #000000;
-  --transport-transport_train-primary-background: #4B2942;
-  --transport-transport_train-primary-text: #FFFFFF;
-  --transport-transport_train-secondary-background: #2C1827;
-  --transport-transport_train-secondary-text: #FFFFFF;
-  --transport-transport_airport-primary-background: #C75B12;
-  --transport-transport_airport-primary-text: #000000;
-  --transport-transport_airport-secondary-background: #97450E;
-  --transport-transport_airport-secondary-text: #FFFFFF;
-  --transport-transport_plane-primary-background: #2B343A;
-  --transport-transport_plane-primary-text: #FFFFFF;
-  --transport-transport_plane-secondary-background: #1A2024;
-  --transport-transport_plane-secondary-text: #FFFFFF;
-  --transport-transport_flexible-primary-background: #C75B12;
+  --transport-transport_region-secondary-text: #ffffff;
+  --transport-transport_airportExpress-primary-background: #a51140;
+  --transport-transport_airportExpress-primary-text: #ffffff;
+  --transport-transport_airportExpress-secondary-background: #7d0d31;
+  --transport-transport_airportExpress-secondary-text: #ffffff;
+  --transport-transport_flexible-primary-background: #c75b12;
   --transport-transport_flexible-primary-text: #000000;
-  --transport-transport_flexible-secondary-background: #97450E;
-  --transport-transport_flexible-secondary-text: #FFFFFF;
-  --transport-transport_bike-primary-background: #A51140;
-  --transport-transport_bike-primary-text: #FFFFFF;
-  --transport-transport_bike-secondary-background: #5C0A24;
-  --transport-transport_bike-secondary-text: #FFFFFF;
-  --transport-transport_scooter-primary-background: #5B6100;
-  --transport-transport_scooter-primary-text: #FFFFFF;
+  --transport-transport_flexible-secondary-background: #97450e;
+  --transport-transport_flexible-secondary-text: #ffffff;
+  --transport-transport_boat-primary-background: #71d6e0;
+  --transport-transport_boat-primary-text: #000000;
+  --transport-transport_boat-secondary-background: #539ca4;
+  --transport-transport_boat-secondary-text: #000000;
+  --transport-transport_train-primary-background: #4b2942;
+  --transport-transport_train-primary-text: #ffffff;
+  --transport-transport_train-secondary-background: #2c1827;
+  --transport-transport_train-secondary-text: #ffffff;
+  --transport-transport_scooter-primary-background: #464a00;
+  --transport-transport_scooter-primary-text: #ffffff;
   --transport-transport_scooter-secondary-background: #323600;
-  --transport-transport_scooter-secondary-text: #FFFFFF;
-  --transport-transport_car-primary-background: #6F5468;
-  --transport-transport_car-primary-text: #FFFFFF;
-  --transport-transport_car-secondary-background: #4B2942;
-  --transport-transport_car-secondary-text: #FFFFFF;
-  --transport-transport_other-primary-background: #C7CACC;
+  --transport-transport_scooter-secondary-text: #ffffff;
+  --transport-transport_car-primary-background: #5b3c53;
+  --transport-transport_car-primary-text: #ffffff;
+  --transport-transport_car-secondary-background: #4b2942;
+  --transport-transport_car-secondary-text: #ffffff;
+  --transport-transport_bike-primary-background: #7d0d31;
+  --transport-transport_bike-primary-text: #ffffff;
+  --transport-transport_bike-secondary-background: #5c0a24;
+  --transport-transport_bike-secondary-text: #ffffff;
+  --transport-transport_other-primary-background: #c7cacc;
   --transport-transport_other-primary-text: #000000;
-  --transport-transport_other-secondary-background: #8D9398;
+  --transport-transport_other-secondary-background: #8d9398;
   --transport-transport_other-secondary-text: #000000;
 
-  --status-valid-primary-background: #909A00;
+  --status-valid-primary-background: #909a00;
   --status-valid-primary-text: #000000;
-  --status-valid-secondary-background: #464A00;
-  --status-valid-secondary-text: #FFFFFF;
-  --status-info-primary-background: #007C92;
-  --status-info-primary-text: #FFFFFF;
+  --status-valid-secondary-background: #464a00;
+  --status-valid-secondary-text: #ffffff;
+  --status-info-primary-background: #007c92;
+  --status-info-primary-text: #ffffff;
   --status-info-secondary-background: #003943;
-  --status-info-secondary-text: #FFFFFF;
-  --status-warning-primary-background: #E4D700;
+  --status-info-secondary-text: #ffffff;
+  --status-warning-primary-background: #e4d700;
   --status-warning-primary-text: #000000;
-  --status-warning-secondary-background: #1F2100;
-  --status-warning-secondary-text: #FFFFFF;
-  --status-error-primary-background: #B74166;
+  --status-warning-secondary-background: #1f2100;
+  --status-warning-secondary-text: #ffffff;
+  --status-error-primary-background: #b74166;
   --status-error-primary-text: #000000;
   --status-error-secondary-background: #380616;
-  --status-error-secondary-text: #FFFFFF;
+  --status-error-secondary-text: #ffffff;
 }
 }
 
@@ -607,13 +610,21 @@
   background-color: var(--transport-transport_region-secondary-background);
   color: var(--transport-transport_region-secondary-text);
 }
-.transport-transport_airport_express-primary {
-  background-color: var(--transport-transport_airport_express-primary-background);
-  color: var(--transport-transport_airport_express-primary-text);
+.transport-transport_airportExpress-primary {
+  background-color: var(--transport-transport_airportExpress-primary-background);
+  color: var(--transport-transport_airportExpress-primary-text);
 }
-.transport-transport_airport_express-secondary {
-  background-color: var(--transport-transport_airport_express-secondary-background);
-  color: var(--transport-transport_airport_express-secondary-text);
+.transport-transport_airportExpress-secondary {
+  background-color: var(--transport-transport_airportExpress-secondary-background);
+  color: var(--transport-transport_airportExpress-secondary-text);
+}
+.transport-transport_flexible-primary {
+  background-color: var(--transport-transport_flexible-primary-background);
+  color: var(--transport-transport_flexible-primary-text);
+}
+.transport-transport_flexible-secondary {
+  background-color: var(--transport-transport_flexible-secondary-background);
+  color: var(--transport-transport_flexible-secondary-text);
 }
 .transport-transport_boat-primary {
   background-color: var(--transport-transport_boat-primary-background);
@@ -631,38 +642,6 @@
   background-color: var(--transport-transport_train-secondary-background);
   color: var(--transport-transport_train-secondary-text);
 }
-.transport-transport_airport-primary {
-  background-color: var(--transport-transport_airport-primary-background);
-  color: var(--transport-transport_airport-primary-text);
-}
-.transport-transport_airport-secondary {
-  background-color: var(--transport-transport_airport-secondary-background);
-  color: var(--transport-transport_airport-secondary-text);
-}
-.transport-transport_plane-primary {
-  background-color: var(--transport-transport_plane-primary-background);
-  color: var(--transport-transport_plane-primary-text);
-}
-.transport-transport_plane-secondary {
-  background-color: var(--transport-transport_plane-secondary-background);
-  color: var(--transport-transport_plane-secondary-text);
-}
-.transport-transport_flexible-primary {
-  background-color: var(--transport-transport_flexible-primary-background);
-  color: var(--transport-transport_flexible-primary-text);
-}
-.transport-transport_flexible-secondary {
-  background-color: var(--transport-transport_flexible-secondary-background);
-  color: var(--transport-transport_flexible-secondary-text);
-}
-.transport-transport_bike-primary {
-  background-color: var(--transport-transport_bike-primary-background);
-  color: var(--transport-transport_bike-primary-text);
-}
-.transport-transport_bike-secondary {
-  background-color: var(--transport-transport_bike-secondary-background);
-  color: var(--transport-transport_bike-secondary-text);
-}
 .transport-transport_scooter-primary {
   background-color: var(--transport-transport_scooter-primary-background);
   color: var(--transport-transport_scooter-primary-text);
@@ -679,6 +658,14 @@
   background-color: var(--transport-transport_car-secondary-background);
   color: var(--transport-transport_car-secondary-text);
 }
+.transport-transport_bike-primary {
+  background-color: var(--transport-transport_bike-primary-background);
+  color: var(--transport-transport_bike-primary-text);
+}
+.transport-transport_bike-secondary {
+  background-color: var(--transport-transport_bike-secondary-background);
+  color: var(--transport-transport_bike-secondary-text);
+}
 .transport-transport_other-primary {
   background-color: var(--transport-transport_other-primary-background);
   color: var(--transport-transport_other-primary-text);
@@ -689,84 +676,24 @@
 }
 
 .interactive-interactive_0 {
-  background-color: var(--interactive-interactive_0-default-background);
-  color: var(--interactive-interactive_0-default-text);
-}
-.interactive-interactive_0:hover {
-  background-color: var(--interactive-interactive_0-hover-background);
-  color: var(--interactive-interactive_0-hover-text);
-}
-.interactive-interactive_0:active {
-  background-color: var(--interactive-interactive_0-active-background);
-  color: var(--interactive-interactive_0-active-text);
-}
-.interactive-interactive_0:disabled {
-  background-color: var(--interactive-interactive_0-disabled-background);
-  color: var(--interactive-interactive_0-disabled-text);
+  background-color: var(--interactive-interactive_0-background);
+  color: var(--interactive-interactive_0-text);
 }
 .interactive-interactive_1 {
-  background-color: var(--interactive-interactive_1-default-background);
-  color: var(--interactive-interactive_1-default-text);
-}
-.interactive-interactive_1:hover {
-  background-color: var(--interactive-interactive_1-hover-background);
-  color: var(--interactive-interactive_1-hover-text);
-}
-.interactive-interactive_1:active {
-  background-color: var(--interactive-interactive_1-active-background);
-  color: var(--interactive-interactive_1-active-text);
-}
-.interactive-interactive_1:disabled {
-  background-color: var(--interactive-interactive_1-disabled-background);
-  color: var(--interactive-interactive_1-disabled-text);
+  background-color: var(--interactive-interactive_1-background);
+  color: var(--interactive-interactive_1-text);
 }
 .interactive-interactive_2 {
-  background-color: var(--interactive-interactive_2-default-background);
-  color: var(--interactive-interactive_2-default-text);
-}
-.interactive-interactive_2:hover {
-  background-color: var(--interactive-interactive_2-hover-background);
-  color: var(--interactive-interactive_2-hover-text);
-}
-.interactive-interactive_2:active {
-  background-color: var(--interactive-interactive_2-active-background);
-  color: var(--interactive-interactive_2-active-text);
-}
-.interactive-interactive_2:disabled {
-  background-color: var(--interactive-interactive_2-disabled-background);
-  color: var(--interactive-interactive_2-disabled-text);
+  background-color: var(--interactive-interactive_2-background);
+  color: var(--interactive-interactive_2-text);
 }
 .interactive-interactive_3 {
-  background-color: var(--interactive-interactive_3-default-background);
-  color: var(--interactive-interactive_3-default-text);
-}
-.interactive-interactive_3:hover {
-  background-color: var(--interactive-interactive_3-hover-background);
-  color: var(--interactive-interactive_3-hover-text);
-}
-.interactive-interactive_3:active {
-  background-color: var(--interactive-interactive_3-active-background);
-  color: var(--interactive-interactive_3-active-text);
-}
-.interactive-interactive_3:disabled {
-  background-color: var(--interactive-interactive_3-disabled-background);
-  color: var(--interactive-interactive_3-disabled-text);
+  background-color: var(--interactive-interactive_3-background);
+  color: var(--interactive-interactive_3-text);
 }
 .interactive-interactive_destructive {
-  background-color: var(--interactive-interactive_destructive-default-background);
-  color: var(--interactive-interactive_destructive-default-text);
-}
-.interactive-interactive_destructive:hover {
-  background-color: var(--interactive-interactive_destructive-hover-background);
-  color: var(--interactive-interactive_destructive-hover-text);
-}
-.interactive-interactive_destructive:active {
-  background-color: var(--interactive-interactive_destructive-active-background);
-  color: var(--interactive-interactive_destructive-active-text);
-}
-.interactive-interactive_destructive:disabled {
-  background-color: var(--interactive-interactive_destructive-disabled-background);
-  color: var(--interactive-interactive_destructive-disabled-text);
+  background-color: var(--interactive-interactive_destructive-background);
+  color: var(--interactive-interactive_destructive-text);
 }
 
 .status-valid-primary {

--- a/packages/theme/src/themes/atb-theme/theme.css
+++ b/packages/theme/src/themes/atb-theme/theme.css
@@ -129,10 +129,10 @@
   --transport-transport_region-primary-text: #ffffff;
   --transport-transport_region-secondary-background: #006678;
   --transport-transport_region-secondary-text: #ffffff;
-  --transport-transport_airportExpress-primary-background: #a51140;
-  --transport-transport_airportExpress-primary-text: #ffffff;
-  --transport-transport_airportExpress-secondary-background: #7d0d31;
-  --transport-transport_airportExpress-secondary-text: #ffffff;
+  --transport-transport_airport_express-primary-background: #a51140;
+  --transport-transport_airport_express-primary-text: #ffffff;
+  --transport-transport_airport_express-secondary-background: #7d0d31;
+  --transport-transport_airport_express-secondary-text: #ffffff;
   --transport-transport_flexible-primary-background: #c75b12;
   --transport-transport_flexible-primary-text: #000000;
   --transport-transport_flexible-secondary-background: #97450e;
@@ -310,10 +310,10 @@
   --transport-transport_region-primary-text: #ffffff;
   --transport-transport_region-secondary-background: #006678;
   --transport-transport_region-secondary-text: #ffffff;
-  --transport-transport_airportExpress-primary-background: #a51140;
-  --transport-transport_airportExpress-primary-text: #ffffff;
-  --transport-transport_airportExpress-secondary-background: #7d0d31;
-  --transport-transport_airportExpress-secondary-text: #ffffff;
+  --transport-transport_airport_express-primary-background: #a51140;
+  --transport-transport_airport_express-primary-text: #ffffff;
+  --transport-transport_airport_express-secondary-background: #7d0d31;
+  --transport-transport_airport_express-secondary-text: #ffffff;
   --transport-transport_flexible-primary-background: #c75b12;
   --transport-transport_flexible-primary-text: #000000;
   --transport-transport_flexible-secondary-background: #97450e;
@@ -491,10 +491,10 @@
   --transport-transport_region-primary-text: #ffffff;
   --transport-transport_region-secondary-background: #006678;
   --transport-transport_region-secondary-text: #ffffff;
-  --transport-transport_airportExpress-primary-background: #a51140;
-  --transport-transport_airportExpress-primary-text: #ffffff;
-  --transport-transport_airportExpress-secondary-background: #7d0d31;
-  --transport-transport_airportExpress-secondary-text: #ffffff;
+  --transport-transport_airport_express-primary-background: #a51140;
+  --transport-transport_airport_express-primary-text: #ffffff;
+  --transport-transport_airport_express-secondary-background: #7d0d31;
+  --transport-transport_airport_express-secondary-text: #ffffff;
   --transport-transport_flexible-primary-background: #c75b12;
   --transport-transport_flexible-primary-text: #000000;
   --transport-transport_flexible-secondary-background: #97450e;
@@ -610,13 +610,13 @@
   background-color: var(--transport-transport_region-secondary-background);
   color: var(--transport-transport_region-secondary-text);
 }
-.transport-transport_airportExpress-primary {
-  background-color: var(--transport-transport_airportExpress-primary-background);
-  color: var(--transport-transport_airportExpress-primary-text);
+.transport-transport_airport_express-primary {
+  background-color: var(--transport-transport_airport_express-primary-background);
+  color: var(--transport-transport_airport_express-primary-text);
 }
-.transport-transport_airportExpress-secondary {
-  background-color: var(--transport-transport_airportExpress-secondary-background);
-  color: var(--transport-transport_airportExpress-secondary-text);
+.transport-transport_airport_express-secondary {
+  background-color: var(--transport-transport_airport_express-secondary-background);
+  color: var(--transport-transport_airport_express-secondary-text);
 }
 .transport-transport_flexible-primary {
   background-color: var(--transport-transport_flexible-primary-background);

--- a/packages/theme/src/themes/atb-theme/theme.module.css
+++ b/packages/theme/src/themes/atb-theme/theme.module.css
@@ -6,7 +6,7 @@
   --border-secondary: #000000;
   --border-focus: #007c92;
   --border-radius-small: 0.25rem;
-  --border-radius-medium: 0.5rem;
+  --border-radius-regular: 0.5rem;
   --border-radius-circle: 1.25rem;
   --border-width-slim: 0.0625rem;
   --border-width-medium: 0.125rem;
@@ -187,7 +187,7 @@
   --border-secondary: #ffffff;
   --border-focus: #448086;
   --border-radius-small: 0.25rem;
-  --border-radius-medium: 0.5rem;
+  --border-radius-regular: 0.5rem;
   --border-radius-circle: 1.25rem;
   --border-width-slim: 0.0625rem;
   --border-width-medium: 0.125rem;
@@ -368,7 +368,7 @@
   --border-secondary: #ffffff;
   --border-focus: #448086;
   --border-radius-small: 0.25rem;
-  --border-radius-medium: 0.5rem;
+  --border-radius-regular: 0.5rem;
   --border-radius-circle: 1.25rem;
   --border-width-slim: 0.0625rem;
   --border-width-medium: 0.125rem;

--- a/packages/theme/src/themes/atb-theme/theme.module.css
+++ b/packages/theme/src/themes/atb-theme/theme.module.css
@@ -2,541 +2,544 @@
 
 /* Light theme data */
 .light {
-  --border-primary: #EEF3F6;
+  --border-primary: #eef3f6;
   --border-secondary: #000000;
-  --border-focus: #007C92;
-  --border-radius-circle: 1.25rem;
-  --border-radius-regular: 0.5rem;
+  --border-focus: #007c92;
   --border-radius-small: 0.25rem;
+  --border-radius-medium: 0.5rem;
+  --border-radius-circle: 1.25rem;
   --border-width-slim: 0.0625rem;
   --border-width-medium: 0.125rem;
 
-  --spacings-xLarge: 1.5rem;
-  --spacings-large: 1.25rem;
-  --spacings-medium: 0.75rem;
-  --spacings-small: 0.5rem;
   --spacings-xSmall: 0.25rem;
+  --spacings-small: 0.5rem;
+  --spacings-medium: 0.75rem;
+  --spacings-large: 1.25rem;
+  --spacings-xLarge: 1.5rem;
 
-  --icon-size-large: 1.75rem;
-  --icon-size-normal: 1.25rem;
-  --icon-size-small: 1rem;
   --icon-size-xSmall: 0.75rem;
+  --icon-size-small: 1rem;
+  --icon-size-medium: 1.25rem;
+  --icon-size-large: 1.625rem;
 
+  --text-light-primary: #ffffff;
+  --text-light-secondary: #e1e7eb;
+  --text-light-disabled: #a9aeb1;
+  --text-dark-primary: #000000;
+  --text-dark-secondary: #555e65;
+  --text-dark-disabled: #a9aeb1;
   --text-colors-primary: #000000;
-  --text-colors-secondary: #555E65;
-  --text-colors-disabled: #A9AEB1;
+  --text-colors-secondary: #555e65;
+  --text-colors-disabled: #a9aeb1;
+  --text-inverse-primary: #ffffff;
+  --text-inverse-secondary: #e1e7eb;
+  --text-inverse-disabled: #a9aeb1;
 
-  --static-background-background_0-background: #FFFFFF;
+  --static-background-background_0-background: #ffffff;
   --static-background-background_0-text: #000000;
-  --static-background-background_1-background: #EEF3F6;
+  --static-background-background_1-background: #eef3f6;
   --static-background-background_1-text: #000000;
-  --static-background-background_2-background: #E1E7EB;
+  --static-background-background_2-background: #e1e7eb;
   --static-background-background_2-text: #000000;
-  --static-background-background_3-background: #D5DCE0;
+  --static-background-background_3-background: #d5dce0;
   --static-background-background_3-text: #000000;
-  --static-background-background_accent_0-background: #37424A;
-  --static-background-background_accent_0-text: #FFFFFF;
-  --static-background-background_accent_1-background: #555E65;
-  --static-background-background_accent_1-text: #FFFFFF;
-  --static-background-background_accent_2-background: #D4E9EC;
+  --static-background-background_accent_0-background: #37424a;
+  --static-background-background_accent_0-text: #ffffff;
+  --static-background-background_accent_1-background: #555e65;
+  --static-background-background_accent_1-text: #ffffff;
+  --static-background-background_accent_2-background: #d4e9ec;
   --static-background-background_accent_2-text: #000000;
-  --static-background-background_accent_3-background: #007C92;
-  --static-background-background_accent_3-text: #FFFFFF;
-  --static-background-background_accent_4-background: #E5E8B8;
+  --static-background-background_accent_3-background: #007c92;
+  --static-background-background_accent_3-text: #ffffff;
+  --static-background-background_accent_4-background: #e5e8b8;
   --static-background-background_accent_4-text: #000000;
-  --static-background-background_accent_5-background: #A6D1D9;
+  --static-background-background_accent_5-background: #a6d1d9;
   --static-background-background_accent_5-text: #000000;
-  --static-zone_selection-from-background: #A2AD00;
+  --static-zone_selection-from-background: #a2ad00;
   --static-zone_selection-from-text: #000000;
-  --static-zone_selection-to-background: #71D6E0;
+  --static-zone_selection-to-background: #71d6e0;
   --static-zone_selection-to-text: #000000;
 
-  --interactive-interactive_0-default-background: #007C92;
-  --interactive-interactive_0-default-text: #FFFFFF;
+  --interactive-interactive_0-default-background: #007c92;
+  --interactive-interactive_0-default-text: #ffffff;
   --interactive-interactive_0-hover-background: #006678;
-  --interactive-interactive_0-hover-text: #FFFFFF;
-  --interactive-interactive_0-active-background: #A6D1D9;
+  --interactive-interactive_0-hover-text: #ffffff;
+  --interactive-interactive_0-active-background: #a6d1d9;
   --interactive-interactive_0-active-text: #000000;
-  --interactive-interactive_0-disabled-background: #D4E9EC;
+  --interactive-interactive_0-disabled-background: #d4e9ec;
   --interactive-interactive_0-disabled-text: #000000;
-  --interactive-interactive_0-outline-background: #71D6E0;
+  --interactive-interactive_0-outline-background: #71d6e0;
   --interactive-interactive_0-outline-text: #000000;
-  --interactive-interactive_0-destructive-background: #A51140;
-  --interactive-interactive_0-destructive-text: #FFFFFF;
-  --interactive-interactive_1-default-background: #555E65;
-  --interactive-interactive_1-default-text: #FFFFFF;
-  --interactive-interactive_1-hover-background: #6F777D;
+  --interactive-interactive_0-background: #a51140;
+  --interactive-interactive_0-text: #ffffff;
+  --interactive-interactive_1-default-background: #555e65;
+  --interactive-interactive_1-default-text: #ffffff;
+  --interactive-interactive_1-hover-background: #6f777d;
   --interactive-interactive_1-hover-text: #000000;
-  --interactive-interactive_1-active-background: #1A2024;
-  --interactive-interactive_1-active-text: #FFFFFF;
-  --interactive-interactive_1-disabled-background: #C7CACC;
+  --interactive-interactive_1-active-background: #1a2024;
+  --interactive-interactive_1-active-text: #ffffff;
+  --interactive-interactive_1-disabled-background: #c7cacc;
   --interactive-interactive_1-disabled-text: #000000;
-  --interactive-interactive_1-outline-background: #007C92;
-  --interactive-interactive_1-outline-text: #FFFFFF;
-  --interactive-interactive_1-destructive-background: #A51140;
-  --interactive-interactive_1-destructive-text: #FFFFFF;
-  --interactive-interactive_2-default-background: #FFFFFF;
+  --interactive-interactive_1-outline-background: #007c92;
+  --interactive-interactive_1-outline-text: #ffffff;
+  --interactive-interactive_1-background: #a51140;
+  --interactive-interactive_1-text: #ffffff;
+  --interactive-interactive_2-default-background: #ffffff;
   --interactive-interactive_2-default-text: #000000;
-  --interactive-interactive_2-hover-background: #D4E9EC;
+  --interactive-interactive_2-hover-background: #d4e9ec;
   --interactive-interactive_2-hover-text: #000000;
-  --interactive-interactive_2-active-background: #A6D1D9;
+  --interactive-interactive_2-active-background: #a6d1d9;
   --interactive-interactive_2-active-text: #000000;
-  --interactive-interactive_2-disabled-background: #FFFFFF;
+  --interactive-interactive_2-disabled-background: #ffffff;
   --interactive-interactive_2-disabled-text: #000000;
-  --interactive-interactive_2-outline-background: #007C92;
-  --interactive-interactive_2-outline-text: #FFFFFF;
-  --interactive-interactive_2-destructive-background: #A51140;
-  --interactive-interactive_2-destructive-text: #FFFFFF;
-  --interactive-interactive_3-default-background: #D4E9EC;
+  --interactive-interactive_2-outline-background: #007c92;
+  --interactive-interactive_2-outline-text: #ffffff;
+  --interactive-interactive_2-background: #a51140;
+  --interactive-interactive_2-text: #ffffff;
+  --interactive-interactive_3-default-background: #d4e9ec;
   --interactive-interactive_3-default-text: #000000;
-  --interactive-interactive_3-hover-background: #A6D1D9;
+  --interactive-interactive_3-hover-background: #a6d1d9;
   --interactive-interactive_3-hover-text: #000000;
-  --interactive-interactive_3-active-background: #A6D1D9;
+  --interactive-interactive_3-active-background: #a6d1d9;
   --interactive-interactive_3-active-text: #000000;
-  --interactive-interactive_3-disabled-background: #E1E7EB;
+  --interactive-interactive_3-disabled-background: #e1e7eb;
   --interactive-interactive_3-disabled-text: #000000;
-  --interactive-interactive_3-outline-background: #004E5C;
-  --interactive-interactive_3-outline-text: #FFFFFF;
-  --interactive-interactive_3-destructive-background: #A51140;
-  --interactive-interactive_3-destructive-text: #FFFFFF;
-  --interactive-interactive_destructive-default-background: #A51140;
-  --interactive-interactive_destructive-default-text: #FFFFFF;
-  --interactive-interactive_destructive-hover-background: #B74166;
+  --interactive-interactive_3-outline-background: #004e5c;
+  --interactive-interactive_3-outline-text: #ffffff;
+  --interactive-interactive_3-background: #a51140;
+  --interactive-interactive_3-text: #ffffff;
+  --interactive-interactive_destructive-default-background: #a51140;
+  --interactive-interactive_destructive-default-text: #ffffff;
+  --interactive-interactive_destructive-hover-background: #b74166;
   --interactive-interactive_destructive-hover-text: #000000;
   --interactive-interactive_destructive-active-background: #380616;
-  --interactive-interactive_destructive-active-text: #FFFFFF;
-  --interactive-interactive_destructive-disabled-background: #EED2DB;
+  --interactive-interactive_destructive-active-text: #ffffff;
+  --interactive-interactive_destructive-disabled-background: #eed2db;
   --interactive-interactive_destructive-disabled-text: #000000;
-  --interactive-interactive_destructive-outline-background: #007C92;
-  --interactive-interactive_destructive-outline-text: #FFFFFF;
-  --interactive-interactive_destructive-destructive-background: #A51140;
-  --interactive-interactive_destructive-destructive-text: #FFFFFF;
+  --interactive-interactive_destructive-outline-background: #007c92;
+  --interactive-interactive_destructive-outline-text: #ffffff;
+  --interactive-interactive_destructive-background: #a51140;
+  --interactive-interactive_destructive-text: #ffffff;
 
-  --transport-transport_city-primary-background: #A2AD00;
+  --transport-transport_city-primary-background: #a2ad00;
   --transport-transport_city-primary-text: #000000;
-  --transport-transport_city-secondary-background: #909A00;
+  --transport-transport_city-secondary-background: #909a00;
   --transport-transport_city-secondary-text: #000000;
-  --transport-transport_region-primary-background: #007C92;
-  --transport-transport_region-primary-text: #FFFFFF;
+  --transport-transport_region-primary-background: #007c92;
+  --transport-transport_region-primary-text: #ffffff;
   --transport-transport_region-secondary-background: #006678;
-  --transport-transport_region-secondary-text: #FFFFFF;
-  --transport-transport_airport_express-primary-background: #A51140;
-  --transport-transport_airport_express-primary-text: #FFFFFF;
-  --transport-transport_airport_express-secondary-background: #7D0D31;
-  --transport-transport_airport_express-secondary-text: #FFFFFF;
-  --transport-transport_boat-primary-background: #71D6E0;
-  --transport-transport_boat-primary-text: #000000;
-  --transport-transport_boat-secondary-background: #539CA4;
-  --transport-transport_boat-secondary-text: #000000;
-  --transport-transport_train-primary-background: #4B2942;
-  --transport-transport_train-primary-text: #FFFFFF;
-  --transport-transport_train-secondary-background: #2C1827;
-  --transport-transport_train-secondary-text: #FFFFFF;
-  --transport-transport_airport-primary-background: #C75B12;
-  --transport-transport_airport-primary-text: #000000;
-  --transport-transport_airport-secondary-background: #97450E;
-  --transport-transport_airport-secondary-text: #FFFFFF;
-  --transport-transport_plane-primary-background: #2B343A;
-  --transport-transport_plane-primary-text: #FFFFFF;
-  --transport-transport_plane-secondary-background: #1A2024;
-  --transport-transport_plane-secondary-text: #FFFFFF;
-  --transport-transport_flexible-primary-background: #C75B12;
+  --transport-transport_region-secondary-text: #ffffff;
+  --transport-transport_airportExpress-primary-background: #a51140;
+  --transport-transport_airportExpress-primary-text: #ffffff;
+  --transport-transport_airportExpress-secondary-background: #7d0d31;
+  --transport-transport_airportExpress-secondary-text: #ffffff;
+  --transport-transport_flexible-primary-background: #c75b12;
   --transport-transport_flexible-primary-text: #000000;
-  --transport-transport_flexible-secondary-background: #97450E;
-  --transport-transport_flexible-secondary-text: #FFFFFF;
-  --transport-transport_bike-primary-background: #7D0D31;
-  --transport-transport_bike-primary-text: #FFFFFF;
-  --transport-transport_bike-secondary-background: #5C0A24;
-  --transport-transport_bike-secondary-text: #FFFFFF;
-  --transport-transport_scooter-primary-background: #464A00;
-  --transport-transport_scooter-primary-text: #FFFFFF;
+  --transport-transport_flexible-secondary-background: #97450e;
+  --transport-transport_flexible-secondary-text: #ffffff;
+  --transport-transport_boat-primary-background: #71d6e0;
+  --transport-transport_boat-primary-text: #000000;
+  --transport-transport_boat-secondary-background: #539ca4;
+  --transport-transport_boat-secondary-text: #000000;
+  --transport-transport_train-primary-background: #4b2942;
+  --transport-transport_train-primary-text: #ffffff;
+  --transport-transport_train-secondary-background: #2c1827;
+  --transport-transport_train-secondary-text: #ffffff;
+  --transport-transport_scooter-primary-background: #464a00;
+  --transport-transport_scooter-primary-text: #ffffff;
   --transport-transport_scooter-secondary-background: #323600;
-  --transport-transport_scooter-secondary-text: #FFFFFF;
-  --transport-transport_car-primary-background: #5B3C53;
-  --transport-transport_car-primary-text: #FFFFFF;
-  --transport-transport_car-secondary-background: #4B2942;
-  --transport-transport_car-secondary-text: #FFFFFF;
-  --transport-transport_other-primary-background: #555E65;
-  --transport-transport_other-primary-text: #FFFFFF;
-  --transport-transport_other-secondary-background: #2B343A;
-  --transport-transport_other-secondary-text: #FFFFFF;
+  --transport-transport_scooter-secondary-text: #ffffff;
+  --transport-transport_car-primary-background: #5b3c53;
+  --transport-transport_car-primary-text: #ffffff;
+  --transport-transport_car-secondary-background: #4b2942;
+  --transport-transport_car-secondary-text: #ffffff;
+  --transport-transport_bike-primary-background: #7d0d31;
+  --transport-transport_bike-primary-text: #ffffff;
+  --transport-transport_bike-secondary-background: #5c0a24;
+  --transport-transport_bike-secondary-text: #ffffff;
+  --transport-transport_other-primary-background: #37424a;
+  --transport-transport_other-primary-text: #ffffff;
+  --transport-transport_other-secondary-background: #2b343a;
+  --transport-transport_other-secondary-text: #ffffff;
 
-  --status-valid-primary-background: #909A00;
+  --status-valid-primary-background: #909a00;
   --status-valid-primary-text: #000000;
-  --status-valid-secondary-background: #E5E8B8;
+  --status-valid-secondary-background: #e5e8b8;
   --status-valid-secondary-text: #000000;
-  --status-info-primary-background: #007C92;
-  --status-info-primary-text: #FFFFFF;
-  --status-info-secondary-background: #DEF5F8;
+  --status-info-primary-background: #007c92;
+  --status-info-primary-text: #ffffff;
+  --status-info-secondary-background: #def5f8;
   --status-info-secondary-text: #000000;
-  --status-warning-primary-background: #E4D700;
+  --status-warning-primary-background: #e4d700;
   --status-warning-primary-text: #000000;
-  --status-warning-secondary-background: #FBF9DA;
+  --status-warning-secondary-background: #fbf9da;
   --status-warning-secondary-text: #000000;
-  --status-error-primary-background: #B74166;
+  --status-error-primary-background: #b74166;
   --status-error-primary-text: #000000;
-  --status-error-secondary-background: #F4E1E7;
+  --status-error-secondary-background: #f4e1e7;
   --status-error-secondary-text: #000000;
 }
 
 
 /* Dark theme data */
 .dark {
-  --border-primary: #242B30;
-  --border-secondary: #FFFFFF;
+  --border-primary: #242b30;
+  --border-secondary: #ffffff;
   --border-focus: #448086;
-  --border-radius-circle: 1.25rem;
-  --border-radius-regular: 0.5rem;
   --border-radius-small: 0.25rem;
+  --border-radius-medium: 0.5rem;
+  --border-radius-circle: 1.25rem;
   --border-width-slim: 0.0625rem;
   --border-width-medium: 0.125rem;
 
-  --spacings-xLarge: 1.5rem;
-  --spacings-large: 1.25rem;
-  --spacings-medium: 0.75rem;
-  --spacings-small: 0.5rem;
   --spacings-xSmall: 0.25rem;
+  --spacings-small: 0.5rem;
+  --spacings-medium: 0.75rem;
+  --spacings-large: 1.25rem;
+  --spacings-xLarge: 1.5rem;
 
-  --icon-size-large: 1.75rem;
-  --icon-size-normal: 1.25rem;
-  --icon-size-small: 1rem;
   --icon-size-xSmall: 0.75rem;
+  --icon-size-small: 1rem;
+  --icon-size-medium: 1.25rem;
+  --icon-size-large: 1.625rem;
 
-  --text-colors-primary: #FFFFFF;
-  --text-colors-secondary: #E1E7EB;
-  --text-colors-disabled: #A9AEB1;
+  --text-light-primary: #ffffff;
+  --text-light-secondary: #e1e7eb;
+  --text-light-disabled: #a9aeb1;
+  --text-dark-primary: #000000;
+  --text-dark-secondary: #555e65;
+  --text-dark-disabled: #a9aeb1;
+  --text-colors-primary: #ffffff;
+  --text-colors-secondary: #e1e7eb;
+  --text-colors-disabled: #a9aeb1;
+  --text-inverse-primary: #000000;
+  --text-inverse-secondary: #555e65;
+  --text-inverse-disabled: #a9aeb1;
 
   --static-background-background_0-background: #000000;
-  --static-background-background_0-text: #FFFFFF;
-  --static-background-background_1-background: #242B30;
-  --static-background-background_1-text: #FFFFFF;
-  --static-background-background_2-background: #37424A;
-  --static-background-background_2-text: #FFFFFF;
-  --static-background-background_3-background: #555E65;
-  --static-background-background_3-text: #FFFFFF;
-  --static-background-background_accent_0-background: #37424A;
-  --static-background-background_accent_0-text: #FFFFFF;
-  --static-background-background_accent_1-background: #555E65;
-  --static-background-background_accent_1-text: #FFFFFF;
-  --static-background-background_accent_2-background: #D4E9EC;
+  --static-background-background_0-text: #ffffff;
+  --static-background-background_1-background: #242b30;
+  --static-background-background_1-text: #ffffff;
+  --static-background-background_2-background: #37424a;
+  --static-background-background_2-text: #ffffff;
+  --static-background-background_3-background: #555e65;
+  --static-background-background_3-text: #ffffff;
+  --static-background-background_accent_0-background: #37424a;
+  --static-background-background_accent_0-text: #ffffff;
+  --static-background-background_accent_1-background: #555e65;
+  --static-background-background_accent_1-text: #ffffff;
+  --static-background-background_accent_2-background: #d4e9ec;
   --static-background-background_accent_2-text: #000000;
-  --static-background-background_accent_3-background: #007C92;
-  --static-background-background_accent_3-text: #FFFFFF;
-  --static-background-background_accent_4-background: #E5E8B8;
+  --static-background-background_accent_3-background: #007c92;
+  --static-background-background_accent_3-text: #ffffff;
+  --static-background-background_accent_4-background: #e5e8b8;
   --static-background-background_accent_4-text: #000000;
-  --static-background-background_accent_5-background: #2B343A;
-  --static-background-background_accent_5-text: #FFFFFF;
-  --static-zone_selection-from-background: #A2AD00;
+  --static-background-background_accent_5-background: #2b343a;
+  --static-background-background_accent_5-text: #ffffff;
+  --static-zone_selection-from-background: #a2ad00;
   --static-zone_selection-from-text: #000000;
-  --static-zone_selection-to-background: #71D6E0;
+  --static-zone_selection-to-background: #71d6e0;
   --static-zone_selection-to-text: #000000;
 
-  --interactive-interactive_0-default-background: #007C92;
-  --interactive-interactive_0-default-text: #FFFFFF;
+  --interactive-interactive_0-default-background: #007c92;
+  --interactive-interactive_0-default-text: #ffffff;
   --interactive-interactive_0-hover-background: #006678;
-  --interactive-interactive_0-hover-text: #FFFFFF;
-  --interactive-interactive_0-active-background: #A6D1D9;
+  --interactive-interactive_0-hover-text: #ffffff;
+  --interactive-interactive_0-active-background: #a6d1d9;
   --interactive-interactive_0-active-text: #000000;
-  --interactive-interactive_0-disabled-background: #D4E9EC;
+  --interactive-interactive_0-disabled-background: #d4e9ec;
   --interactive-interactive_0-disabled-text: #000000;
-  --interactive-interactive_0-outline-background: #71D6E0;
+  --interactive-interactive_0-outline-background: #71d6e0;
   --interactive-interactive_0-outline-text: #000000;
-  --interactive-interactive_0-destructive-background: #D691A7;
-  --interactive-interactive_0-destructive-text: #000000;
-  --interactive-interactive_1-default-background: #555E65;
-  --interactive-interactive_1-default-text: #FFFFFF;
-  --interactive-interactive_1-hover-background: #6F777D;
+  --interactive-interactive_0-background: #d692a7;
+  --interactive-interactive_0-text: #000000;
+  --interactive-interactive_1-default-background: #555e65;
+  --interactive-interactive_1-default-text: #ffffff;
+  --interactive-interactive_1-hover-background: #6f777d;
   --interactive-interactive_1-hover-text: #000000;
-  --interactive-interactive_1-active-background: #1A2024;
-  --interactive-interactive_1-active-text: #FFFFFF;
-  --interactive-interactive_1-disabled-background: #C7CACC;
+  --interactive-interactive_1-active-background: #1a2024;
+  --interactive-interactive_1-active-text: #ffffff;
+  --interactive-interactive_1-disabled-background: #c7cacc;
   --interactive-interactive_1-disabled-text: #000000;
-  --interactive-interactive_1-outline-background: #007C92;
-  --interactive-interactive_1-outline-text: #FFFFFF;
-  --interactive-interactive_1-destructive-background: #D691A7;
-  --interactive-interactive_1-destructive-text: #000000;
+  --interactive-interactive_1-outline-background: #007c92;
+  --interactive-interactive_1-outline-text: #ffffff;
+  --interactive-interactive_1-background: #d692a7;
+  --interactive-interactive_1-text: #000000;
   --interactive-interactive_2-default-background: #000000;
-  --interactive-interactive_2-default-text: #FFFFFF;
+  --interactive-interactive_2-default-text: #ffffff;
   --interactive-interactive_2-hover-background: #002329;
-  --interactive-interactive_2-hover-text: #FFFFFF;
-  --interactive-interactive_2-active-background: #004E5C;
-  --interactive-interactive_2-active-text: #FFFFFF;
+  --interactive-interactive_2-hover-text: #ffffff;
+  --interactive-interactive_2-active-background: #004e5c;
+  --interactive-interactive_2-active-text: #ffffff;
   --interactive-interactive_2-disabled-background: #000000;
-  --interactive-interactive_2-disabled-text: #FFFFFF;
-  --interactive-interactive_2-outline-background: #007C92;
-  --interactive-interactive_2-outline-text: #FFFFFF;
-  --interactive-interactive_2-destructive-background: #D691A7;
-  --interactive-interactive_2-destructive-text: #000000;
-  --interactive-interactive_3-default-background: #004E5C;
-  --interactive-interactive_3-default-text: #FFFFFF;
+  --interactive-interactive_2-disabled-text: #ffffff;
+  --interactive-interactive_2-outline-background: #007c92;
+  --interactive-interactive_2-outline-text: #ffffff;
+  --interactive-interactive_2-background: #d692a7;
+  --interactive-interactive_2-text: #000000;
+  --interactive-interactive_3-default-background: #004e5c;
+  --interactive-interactive_3-default-text: #ffffff;
   --interactive-interactive_3-hover-background: #003943;
-  --interactive-interactive_3-hover-text: #FFFFFF;
+  --interactive-interactive_3-hover-text: #ffffff;
   --interactive-interactive_3-active-background: #003943;
-  --interactive-interactive_3-active-text: #FFFFFF;
-  --interactive-interactive_3-disabled-background: #555E65;
-  --interactive-interactive_3-disabled-text: #FFFFFF;
-  --interactive-interactive_3-outline-background: #D4E9EC;
+  --interactive-interactive_3-active-text: #ffffff;
+  --interactive-interactive_3-disabled-background: #555e65;
+  --interactive-interactive_3-disabled-text: #ffffff;
+  --interactive-interactive_3-outline-background: #d4e9ec;
   --interactive-interactive_3-outline-text: #000000;
-  --interactive-interactive_3-destructive-background: #A51140;
-  --interactive-interactive_3-destructive-text: #FFFFFF;
-  --interactive-interactive_destructive-default-background: #A51140;
-  --interactive-interactive_destructive-default-text: #FFFFFF;
-  --interactive-interactive_destructive-hover-background: #B74166;
+  --interactive-interactive_3-background: #a51140;
+  --interactive-interactive_3-text: #ffffff;
+  --interactive-interactive_destructive-default-background: #a51140;
+  --interactive-interactive_destructive-default-text: #ffffff;
+  --interactive-interactive_destructive-hover-background: #b74166;
   --interactive-interactive_destructive-hover-text: #000000;
   --interactive-interactive_destructive-active-background: #380616;
-  --interactive-interactive_destructive-active-text: #FFFFFF;
-  --interactive-interactive_destructive-disabled-background: #EED2DB;
+  --interactive-interactive_destructive-active-text: #ffffff;
+  --interactive-interactive_destructive-disabled-background: #eed2db;
   --interactive-interactive_destructive-disabled-text: #000000;
-  --interactive-interactive_destructive-outline-background: #007C92;
-  --interactive-interactive_destructive-outline-text: #FFFFFF;
-  --interactive-interactive_destructive-destructive-background: #D691A7;
-  --interactive-interactive_destructive-destructive-text: #000000;
+  --interactive-interactive_destructive-outline-background: #007c92;
+  --interactive-interactive_destructive-outline-text: #ffffff;
+  --interactive-interactive_destructive-background: #d692a7;
+  --interactive-interactive_destructive-text: #000000;
 
-  --transport-transport_city-primary-background: #A2AD00;
+  --transport-transport_city-primary-background: #a2ad00;
   --transport-transport_city-primary-text: #000000;
-  --transport-transport_city-secondary-background: #909A00;
+  --transport-transport_city-secondary-background: #909a00;
   --transport-transport_city-secondary-text: #000000;
-  --transport-transport_region-primary-background: #007C92;
-  --transport-transport_region-primary-text: #FFFFFF;
+  --transport-transport_region-primary-background: #007c92;
+  --transport-transport_region-primary-text: #ffffff;
   --transport-transport_region-secondary-background: #006678;
-  --transport-transport_region-secondary-text: #FFFFFF;
-  --transport-transport_airport_express-primary-background: #A51140;
-  --transport-transport_airport_express-primary-text: #FFFFFF;
-  --transport-transport_airport_express-secondary-background: #7D0D31;
-  --transport-transport_airport_express-secondary-text: #FFFFFF;
-  --transport-transport_boat-primary-background: #71D6E0;
-  --transport-transport_boat-primary-text: #000000;
-  --transport-transport_boat-secondary-background: #539CA4;
-  --transport-transport_boat-secondary-text: #000000;
-  --transport-transport_train-primary-background: #4B2942;
-  --transport-transport_train-primary-text: #FFFFFF;
-  --transport-transport_train-secondary-background: #2C1827;
-  --transport-transport_train-secondary-text: #FFFFFF;
-  --transport-transport_airport-primary-background: #C75B12;
-  --transport-transport_airport-primary-text: #000000;
-  --transport-transport_airport-secondary-background: #97450E;
-  --transport-transport_airport-secondary-text: #FFFFFF;
-  --transport-transport_plane-primary-background: #2B343A;
-  --transport-transport_plane-primary-text: #FFFFFF;
-  --transport-transport_plane-secondary-background: #1A2024;
-  --transport-transport_plane-secondary-text: #FFFFFF;
-  --transport-transport_flexible-primary-background: #C75B12;
+  --transport-transport_region-secondary-text: #ffffff;
+  --transport-transport_airportExpress-primary-background: #a51140;
+  --transport-transport_airportExpress-primary-text: #ffffff;
+  --transport-transport_airportExpress-secondary-background: #7d0d31;
+  --transport-transport_airportExpress-secondary-text: #ffffff;
+  --transport-transport_flexible-primary-background: #c75b12;
   --transport-transport_flexible-primary-text: #000000;
-  --transport-transport_flexible-secondary-background: #97450E;
-  --transport-transport_flexible-secondary-text: #FFFFFF;
-  --transport-transport_bike-primary-background: #A51140;
-  --transport-transport_bike-primary-text: #FFFFFF;
-  --transport-transport_bike-secondary-background: #5C0A24;
-  --transport-transport_bike-secondary-text: #FFFFFF;
-  --transport-transport_scooter-primary-background: #5B6100;
-  --transport-transport_scooter-primary-text: #FFFFFF;
+  --transport-transport_flexible-secondary-background: #97450e;
+  --transport-transport_flexible-secondary-text: #ffffff;
+  --transport-transport_boat-primary-background: #71d6e0;
+  --transport-transport_boat-primary-text: #000000;
+  --transport-transport_boat-secondary-background: #539ca4;
+  --transport-transport_boat-secondary-text: #000000;
+  --transport-transport_train-primary-background: #4b2942;
+  --transport-transport_train-primary-text: #ffffff;
+  --transport-transport_train-secondary-background: #2c1827;
+  --transport-transport_train-secondary-text: #ffffff;
+  --transport-transport_scooter-primary-background: #464a00;
+  --transport-transport_scooter-primary-text: #ffffff;
   --transport-transport_scooter-secondary-background: #323600;
-  --transport-transport_scooter-secondary-text: #FFFFFF;
-  --transport-transport_car-primary-background: #6F5468;
-  --transport-transport_car-primary-text: #FFFFFF;
-  --transport-transport_car-secondary-background: #4B2942;
-  --transport-transport_car-secondary-text: #FFFFFF;
-  --transport-transport_other-primary-background: #C7CACC;
+  --transport-transport_scooter-secondary-text: #ffffff;
+  --transport-transport_car-primary-background: #5b3c53;
+  --transport-transport_car-primary-text: #ffffff;
+  --transport-transport_car-secondary-background: #4b2942;
+  --transport-transport_car-secondary-text: #ffffff;
+  --transport-transport_bike-primary-background: #7d0d31;
+  --transport-transport_bike-primary-text: #ffffff;
+  --transport-transport_bike-secondary-background: #5c0a24;
+  --transport-transport_bike-secondary-text: #ffffff;
+  --transport-transport_other-primary-background: #c7cacc;
   --transport-transport_other-primary-text: #000000;
-  --transport-transport_other-secondary-background: #8D9398;
+  --transport-transport_other-secondary-background: #8d9398;
   --transport-transport_other-secondary-text: #000000;
 
-  --status-valid-primary-background: #909A00;
+  --status-valid-primary-background: #909a00;
   --status-valid-primary-text: #000000;
-  --status-valid-secondary-background: #464A00;
-  --status-valid-secondary-text: #FFFFFF;
-  --status-info-primary-background: #007C92;
-  --status-info-primary-text: #FFFFFF;
+  --status-valid-secondary-background: #464a00;
+  --status-valid-secondary-text: #ffffff;
+  --status-info-primary-background: #007c92;
+  --status-info-primary-text: #ffffff;
   --status-info-secondary-background: #003943;
-  --status-info-secondary-text: #FFFFFF;
-  --status-warning-primary-background: #E4D700;
+  --status-info-secondary-text: #ffffff;
+  --status-warning-primary-background: #e4d700;
   --status-warning-primary-text: #000000;
-  --status-warning-secondary-background: #1F2100;
-  --status-warning-secondary-text: #FFFFFF;
-  --status-error-primary-background: #B74166;
+  --status-warning-secondary-background: #1f2100;
+  --status-warning-secondary-text: #ffffff;
+  --status-error-primary-background: #b74166;
   --status-error-primary-text: #000000;
   --status-error-secondary-background: #380616;
-  --status-error-secondary-text: #FFFFFF;
+  --status-error-secondary-text: #ffffff;
 }
 
 
 @media (prefers-color-scheme: dark) {
   .light:not(.override-light) {
-  --border-primary: #242B30;
-  --border-secondary: #FFFFFF;
+  --border-primary: #242b30;
+  --border-secondary: #ffffff;
   --border-focus: #448086;
-  --border-radius-circle: 1.25rem;
-  --border-radius-regular: 0.5rem;
   --border-radius-small: 0.25rem;
+  --border-radius-medium: 0.5rem;
+  --border-radius-circle: 1.25rem;
   --border-width-slim: 0.0625rem;
   --border-width-medium: 0.125rem;
 
-  --spacings-xLarge: 1.5rem;
-  --spacings-large: 1.25rem;
-  --spacings-medium: 0.75rem;
-  --spacings-small: 0.5rem;
   --spacings-xSmall: 0.25rem;
+  --spacings-small: 0.5rem;
+  --spacings-medium: 0.75rem;
+  --spacings-large: 1.25rem;
+  --spacings-xLarge: 1.5rem;
 
-  --icon-size-large: 1.75rem;
-  --icon-size-normal: 1.25rem;
-  --icon-size-small: 1rem;
   --icon-size-xSmall: 0.75rem;
+  --icon-size-small: 1rem;
+  --icon-size-medium: 1.25rem;
+  --icon-size-large: 1.625rem;
 
-  --text-colors-primary: #FFFFFF;
-  --text-colors-secondary: #E1E7EB;
-  --text-colors-disabled: #A9AEB1;
+  --text-light-primary: #ffffff;
+  --text-light-secondary: #e1e7eb;
+  --text-light-disabled: #a9aeb1;
+  --text-dark-primary: #000000;
+  --text-dark-secondary: #555e65;
+  --text-dark-disabled: #a9aeb1;
+  --text-colors-primary: #ffffff;
+  --text-colors-secondary: #e1e7eb;
+  --text-colors-disabled: #a9aeb1;
+  --text-inverse-primary: #000000;
+  --text-inverse-secondary: #555e65;
+  --text-inverse-disabled: #a9aeb1;
 
   --static-background-background_0-background: #000000;
-  --static-background-background_0-text: #FFFFFF;
-  --static-background-background_1-background: #242B30;
-  --static-background-background_1-text: #FFFFFF;
-  --static-background-background_2-background: #37424A;
-  --static-background-background_2-text: #FFFFFF;
-  --static-background-background_3-background: #555E65;
-  --static-background-background_3-text: #FFFFFF;
-  --static-background-background_accent_0-background: #37424A;
-  --static-background-background_accent_0-text: #FFFFFF;
-  --static-background-background_accent_1-background: #555E65;
-  --static-background-background_accent_1-text: #FFFFFF;
-  --static-background-background_accent_2-background: #D4E9EC;
+  --static-background-background_0-text: #ffffff;
+  --static-background-background_1-background: #242b30;
+  --static-background-background_1-text: #ffffff;
+  --static-background-background_2-background: #37424a;
+  --static-background-background_2-text: #ffffff;
+  --static-background-background_3-background: #555e65;
+  --static-background-background_3-text: #ffffff;
+  --static-background-background_accent_0-background: #37424a;
+  --static-background-background_accent_0-text: #ffffff;
+  --static-background-background_accent_1-background: #555e65;
+  --static-background-background_accent_1-text: #ffffff;
+  --static-background-background_accent_2-background: #d4e9ec;
   --static-background-background_accent_2-text: #000000;
-  --static-background-background_accent_3-background: #007C92;
-  --static-background-background_accent_3-text: #FFFFFF;
-  --static-background-background_accent_4-background: #E5E8B8;
+  --static-background-background_accent_3-background: #007c92;
+  --static-background-background_accent_3-text: #ffffff;
+  --static-background-background_accent_4-background: #e5e8b8;
   --static-background-background_accent_4-text: #000000;
-  --static-background-background_accent_5-background: #2B343A;
-  --static-background-background_accent_5-text: #FFFFFF;
-  --static-zone_selection-from-background: #A2AD00;
+  --static-background-background_accent_5-background: #2b343a;
+  --static-background-background_accent_5-text: #ffffff;
+  --static-zone_selection-from-background: #a2ad00;
   --static-zone_selection-from-text: #000000;
-  --static-zone_selection-to-background: #71D6E0;
+  --static-zone_selection-to-background: #71d6e0;
   --static-zone_selection-to-text: #000000;
 
-  --interactive-interactive_0-default-background: #007C92;
-  --interactive-interactive_0-default-text: #FFFFFF;
+  --interactive-interactive_0-default-background: #007c92;
+  --interactive-interactive_0-default-text: #ffffff;
   --interactive-interactive_0-hover-background: #006678;
-  --interactive-interactive_0-hover-text: #FFFFFF;
-  --interactive-interactive_0-active-background: #A6D1D9;
+  --interactive-interactive_0-hover-text: #ffffff;
+  --interactive-interactive_0-active-background: #a6d1d9;
   --interactive-interactive_0-active-text: #000000;
-  --interactive-interactive_0-disabled-background: #D4E9EC;
+  --interactive-interactive_0-disabled-background: #d4e9ec;
   --interactive-interactive_0-disabled-text: #000000;
-  --interactive-interactive_0-outline-background: #71D6E0;
+  --interactive-interactive_0-outline-background: #71d6e0;
   --interactive-interactive_0-outline-text: #000000;
-  --interactive-interactive_0-destructive-background: #D691A7;
-  --interactive-interactive_0-destructive-text: #000000;
-  --interactive-interactive_1-default-background: #555E65;
-  --interactive-interactive_1-default-text: #FFFFFF;
-  --interactive-interactive_1-hover-background: #6F777D;
+  --interactive-interactive_0-background: #d692a7;
+  --interactive-interactive_0-text: #000000;
+  --interactive-interactive_1-default-background: #555e65;
+  --interactive-interactive_1-default-text: #ffffff;
+  --interactive-interactive_1-hover-background: #6f777d;
   --interactive-interactive_1-hover-text: #000000;
-  --interactive-interactive_1-active-background: #1A2024;
-  --interactive-interactive_1-active-text: #FFFFFF;
-  --interactive-interactive_1-disabled-background: #C7CACC;
+  --interactive-interactive_1-active-background: #1a2024;
+  --interactive-interactive_1-active-text: #ffffff;
+  --interactive-interactive_1-disabled-background: #c7cacc;
   --interactive-interactive_1-disabled-text: #000000;
-  --interactive-interactive_1-outline-background: #007C92;
-  --interactive-interactive_1-outline-text: #FFFFFF;
-  --interactive-interactive_1-destructive-background: #D691A7;
-  --interactive-interactive_1-destructive-text: #000000;
+  --interactive-interactive_1-outline-background: #007c92;
+  --interactive-interactive_1-outline-text: #ffffff;
+  --interactive-interactive_1-background: #d692a7;
+  --interactive-interactive_1-text: #000000;
   --interactive-interactive_2-default-background: #000000;
-  --interactive-interactive_2-default-text: #FFFFFF;
+  --interactive-interactive_2-default-text: #ffffff;
   --interactive-interactive_2-hover-background: #002329;
-  --interactive-interactive_2-hover-text: #FFFFFF;
-  --interactive-interactive_2-active-background: #004E5C;
-  --interactive-interactive_2-active-text: #FFFFFF;
+  --interactive-interactive_2-hover-text: #ffffff;
+  --interactive-interactive_2-active-background: #004e5c;
+  --interactive-interactive_2-active-text: #ffffff;
   --interactive-interactive_2-disabled-background: #000000;
-  --interactive-interactive_2-disabled-text: #FFFFFF;
-  --interactive-interactive_2-outline-background: #007C92;
-  --interactive-interactive_2-outline-text: #FFFFFF;
-  --interactive-interactive_2-destructive-background: #D691A7;
-  --interactive-interactive_2-destructive-text: #000000;
-  --interactive-interactive_3-default-background: #004E5C;
-  --interactive-interactive_3-default-text: #FFFFFF;
+  --interactive-interactive_2-disabled-text: #ffffff;
+  --interactive-interactive_2-outline-background: #007c92;
+  --interactive-interactive_2-outline-text: #ffffff;
+  --interactive-interactive_2-background: #d692a7;
+  --interactive-interactive_2-text: #000000;
+  --interactive-interactive_3-default-background: #004e5c;
+  --interactive-interactive_3-default-text: #ffffff;
   --interactive-interactive_3-hover-background: #003943;
-  --interactive-interactive_3-hover-text: #FFFFFF;
+  --interactive-interactive_3-hover-text: #ffffff;
   --interactive-interactive_3-active-background: #003943;
-  --interactive-interactive_3-active-text: #FFFFFF;
-  --interactive-interactive_3-disabled-background: #555E65;
-  --interactive-interactive_3-disabled-text: #FFFFFF;
-  --interactive-interactive_3-outline-background: #D4E9EC;
+  --interactive-interactive_3-active-text: #ffffff;
+  --interactive-interactive_3-disabled-background: #555e65;
+  --interactive-interactive_3-disabled-text: #ffffff;
+  --interactive-interactive_3-outline-background: #d4e9ec;
   --interactive-interactive_3-outline-text: #000000;
-  --interactive-interactive_3-destructive-background: #A51140;
-  --interactive-interactive_3-destructive-text: #FFFFFF;
-  --interactive-interactive_destructive-default-background: #A51140;
-  --interactive-interactive_destructive-default-text: #FFFFFF;
-  --interactive-interactive_destructive-hover-background: #B74166;
+  --interactive-interactive_3-background: #a51140;
+  --interactive-interactive_3-text: #ffffff;
+  --interactive-interactive_destructive-default-background: #a51140;
+  --interactive-interactive_destructive-default-text: #ffffff;
+  --interactive-interactive_destructive-hover-background: #b74166;
   --interactive-interactive_destructive-hover-text: #000000;
   --interactive-interactive_destructive-active-background: #380616;
-  --interactive-interactive_destructive-active-text: #FFFFFF;
-  --interactive-interactive_destructive-disabled-background: #EED2DB;
+  --interactive-interactive_destructive-active-text: #ffffff;
+  --interactive-interactive_destructive-disabled-background: #eed2db;
   --interactive-interactive_destructive-disabled-text: #000000;
-  --interactive-interactive_destructive-outline-background: #007C92;
-  --interactive-interactive_destructive-outline-text: #FFFFFF;
-  --interactive-interactive_destructive-destructive-background: #D691A7;
-  --interactive-interactive_destructive-destructive-text: #000000;
+  --interactive-interactive_destructive-outline-background: #007c92;
+  --interactive-interactive_destructive-outline-text: #ffffff;
+  --interactive-interactive_destructive-background: #d692a7;
+  --interactive-interactive_destructive-text: #000000;
 
-  --transport-transport_city-primary-background: #A2AD00;
+  --transport-transport_city-primary-background: #a2ad00;
   --transport-transport_city-primary-text: #000000;
-  --transport-transport_city-secondary-background: #909A00;
+  --transport-transport_city-secondary-background: #909a00;
   --transport-transport_city-secondary-text: #000000;
-  --transport-transport_region-primary-background: #007C92;
-  --transport-transport_region-primary-text: #FFFFFF;
+  --transport-transport_region-primary-background: #007c92;
+  --transport-transport_region-primary-text: #ffffff;
   --transport-transport_region-secondary-background: #006678;
-  --transport-transport_region-secondary-text: #FFFFFF;
-  --transport-transport_airport_express-primary-background: #A51140;
-  --transport-transport_airport_express-primary-text: #FFFFFF;
-  --transport-transport_airport_express-secondary-background: #7D0D31;
-  --transport-transport_airport_express-secondary-text: #FFFFFF;
-  --transport-transport_boat-primary-background: #71D6E0;
-  --transport-transport_boat-primary-text: #000000;
-  --transport-transport_boat-secondary-background: #539CA4;
-  --transport-transport_boat-secondary-text: #000000;
-  --transport-transport_train-primary-background: #4B2942;
-  --transport-transport_train-primary-text: #FFFFFF;
-  --transport-transport_train-secondary-background: #2C1827;
-  --transport-transport_train-secondary-text: #FFFFFF;
-  --transport-transport_airport-primary-background: #C75B12;
-  --transport-transport_airport-primary-text: #000000;
-  --transport-transport_airport-secondary-background: #97450E;
-  --transport-transport_airport-secondary-text: #FFFFFF;
-  --transport-transport_plane-primary-background: #2B343A;
-  --transport-transport_plane-primary-text: #FFFFFF;
-  --transport-transport_plane-secondary-background: #1A2024;
-  --transport-transport_plane-secondary-text: #FFFFFF;
-  --transport-transport_flexible-primary-background: #C75B12;
+  --transport-transport_region-secondary-text: #ffffff;
+  --transport-transport_airportExpress-primary-background: #a51140;
+  --transport-transport_airportExpress-primary-text: #ffffff;
+  --transport-transport_airportExpress-secondary-background: #7d0d31;
+  --transport-transport_airportExpress-secondary-text: #ffffff;
+  --transport-transport_flexible-primary-background: #c75b12;
   --transport-transport_flexible-primary-text: #000000;
-  --transport-transport_flexible-secondary-background: #97450E;
-  --transport-transport_flexible-secondary-text: #FFFFFF;
-  --transport-transport_bike-primary-background: #A51140;
-  --transport-transport_bike-primary-text: #FFFFFF;
-  --transport-transport_bike-secondary-background: #5C0A24;
-  --transport-transport_bike-secondary-text: #FFFFFF;
-  --transport-transport_scooter-primary-background: #5B6100;
-  --transport-transport_scooter-primary-text: #FFFFFF;
+  --transport-transport_flexible-secondary-background: #97450e;
+  --transport-transport_flexible-secondary-text: #ffffff;
+  --transport-transport_boat-primary-background: #71d6e0;
+  --transport-transport_boat-primary-text: #000000;
+  --transport-transport_boat-secondary-background: #539ca4;
+  --transport-transport_boat-secondary-text: #000000;
+  --transport-transport_train-primary-background: #4b2942;
+  --transport-transport_train-primary-text: #ffffff;
+  --transport-transport_train-secondary-background: #2c1827;
+  --transport-transport_train-secondary-text: #ffffff;
+  --transport-transport_scooter-primary-background: #464a00;
+  --transport-transport_scooter-primary-text: #ffffff;
   --transport-transport_scooter-secondary-background: #323600;
-  --transport-transport_scooter-secondary-text: #FFFFFF;
-  --transport-transport_car-primary-background: #6F5468;
-  --transport-transport_car-primary-text: #FFFFFF;
-  --transport-transport_car-secondary-background: #4B2942;
-  --transport-transport_car-secondary-text: #FFFFFF;
-  --transport-transport_other-primary-background: #C7CACC;
+  --transport-transport_scooter-secondary-text: #ffffff;
+  --transport-transport_car-primary-background: #5b3c53;
+  --transport-transport_car-primary-text: #ffffff;
+  --transport-transport_car-secondary-background: #4b2942;
+  --transport-transport_car-secondary-text: #ffffff;
+  --transport-transport_bike-primary-background: #7d0d31;
+  --transport-transport_bike-primary-text: #ffffff;
+  --transport-transport_bike-secondary-background: #5c0a24;
+  --transport-transport_bike-secondary-text: #ffffff;
+  --transport-transport_other-primary-background: #c7cacc;
   --transport-transport_other-primary-text: #000000;
-  --transport-transport_other-secondary-background: #8D9398;
+  --transport-transport_other-secondary-background: #8d9398;
   --transport-transport_other-secondary-text: #000000;
 
-  --status-valid-primary-background: #909A00;
+  --status-valid-primary-background: #909a00;
   --status-valid-primary-text: #000000;
-  --status-valid-secondary-background: #464A00;
-  --status-valid-secondary-text: #FFFFFF;
-  --status-info-primary-background: #007C92;
-  --status-info-primary-text: #FFFFFF;
+  --status-valid-secondary-background: #464a00;
+  --status-valid-secondary-text: #ffffff;
+  --status-info-primary-background: #007c92;
+  --status-info-primary-text: #ffffff;
   --status-info-secondary-background: #003943;
-  --status-info-secondary-text: #FFFFFF;
-  --status-warning-primary-background: #E4D700;
+  --status-info-secondary-text: #ffffff;
+  --status-warning-primary-background: #e4d700;
   --status-warning-primary-text: #000000;
-  --status-warning-secondary-background: #1F2100;
-  --status-warning-secondary-text: #FFFFFF;
-  --status-error-primary-background: #B74166;
+  --status-warning-secondary-background: #1f2100;
+  --status-warning-secondary-text: #ffffff;
+  --status-error-primary-background: #b74166;
   --status-error-primary-text: #000000;
   --status-error-secondary-background: #380616;
-  --status-error-secondary-text: #FFFFFF;
+  --status-error-secondary-text: #ffffff;
 }
 }
 
@@ -607,13 +610,21 @@
   background-color: var(--transport-transport_region-secondary-background);
   color: var(--transport-transport_region-secondary-text);
 }
-.transport-transport_airport_express-primary {
-  background-color: var(--transport-transport_airport_express-primary-background);
-  color: var(--transport-transport_airport_express-primary-text);
+.transport-transport_airportExpress-primary {
+  background-color: var(--transport-transport_airportExpress-primary-background);
+  color: var(--transport-transport_airportExpress-primary-text);
 }
-.transport-transport_airport_express-secondary {
-  background-color: var(--transport-transport_airport_express-secondary-background);
-  color: var(--transport-transport_airport_express-secondary-text);
+.transport-transport_airportExpress-secondary {
+  background-color: var(--transport-transport_airportExpress-secondary-background);
+  color: var(--transport-transport_airportExpress-secondary-text);
+}
+.transport-transport_flexible-primary {
+  background-color: var(--transport-transport_flexible-primary-background);
+  color: var(--transport-transport_flexible-primary-text);
+}
+.transport-transport_flexible-secondary {
+  background-color: var(--transport-transport_flexible-secondary-background);
+  color: var(--transport-transport_flexible-secondary-text);
 }
 .transport-transport_boat-primary {
   background-color: var(--transport-transport_boat-primary-background);
@@ -631,38 +642,6 @@
   background-color: var(--transport-transport_train-secondary-background);
   color: var(--transport-transport_train-secondary-text);
 }
-.transport-transport_airport-primary {
-  background-color: var(--transport-transport_airport-primary-background);
-  color: var(--transport-transport_airport-primary-text);
-}
-.transport-transport_airport-secondary {
-  background-color: var(--transport-transport_airport-secondary-background);
-  color: var(--transport-transport_airport-secondary-text);
-}
-.transport-transport_plane-primary {
-  background-color: var(--transport-transport_plane-primary-background);
-  color: var(--transport-transport_plane-primary-text);
-}
-.transport-transport_plane-secondary {
-  background-color: var(--transport-transport_plane-secondary-background);
-  color: var(--transport-transport_plane-secondary-text);
-}
-.transport-transport_flexible-primary {
-  background-color: var(--transport-transport_flexible-primary-background);
-  color: var(--transport-transport_flexible-primary-text);
-}
-.transport-transport_flexible-secondary {
-  background-color: var(--transport-transport_flexible-secondary-background);
-  color: var(--transport-transport_flexible-secondary-text);
-}
-.transport-transport_bike-primary {
-  background-color: var(--transport-transport_bike-primary-background);
-  color: var(--transport-transport_bike-primary-text);
-}
-.transport-transport_bike-secondary {
-  background-color: var(--transport-transport_bike-secondary-background);
-  color: var(--transport-transport_bike-secondary-text);
-}
 .transport-transport_scooter-primary {
   background-color: var(--transport-transport_scooter-primary-background);
   color: var(--transport-transport_scooter-primary-text);
@@ -679,6 +658,14 @@
   background-color: var(--transport-transport_car-secondary-background);
   color: var(--transport-transport_car-secondary-text);
 }
+.transport-transport_bike-primary {
+  background-color: var(--transport-transport_bike-primary-background);
+  color: var(--transport-transport_bike-primary-text);
+}
+.transport-transport_bike-secondary {
+  background-color: var(--transport-transport_bike-secondary-background);
+  color: var(--transport-transport_bike-secondary-text);
+}
 .transport-transport_other-primary {
   background-color: var(--transport-transport_other-primary-background);
   color: var(--transport-transport_other-primary-text);
@@ -689,84 +676,24 @@
 }
 
 .interactive-interactive_0 {
-  background-color: var(--interactive-interactive_0-default-background);
-  color: var(--interactive-interactive_0-default-text);
-}
-.interactive-interactive_0:hover {
-  background-color: var(--interactive-interactive_0-hover-background);
-  color: var(--interactive-interactive_0-hover-text);
-}
-.interactive-interactive_0:active {
-  background-color: var(--interactive-interactive_0-active-background);
-  color: var(--interactive-interactive_0-active-text);
-}
-.interactive-interactive_0:disabled {
-  background-color: var(--interactive-interactive_0-disabled-background);
-  color: var(--interactive-interactive_0-disabled-text);
+  background-color: var(--interactive-interactive_0-background);
+  color: var(--interactive-interactive_0-text);
 }
 .interactive-interactive_1 {
-  background-color: var(--interactive-interactive_1-default-background);
-  color: var(--interactive-interactive_1-default-text);
-}
-.interactive-interactive_1:hover {
-  background-color: var(--interactive-interactive_1-hover-background);
-  color: var(--interactive-interactive_1-hover-text);
-}
-.interactive-interactive_1:active {
-  background-color: var(--interactive-interactive_1-active-background);
-  color: var(--interactive-interactive_1-active-text);
-}
-.interactive-interactive_1:disabled {
-  background-color: var(--interactive-interactive_1-disabled-background);
-  color: var(--interactive-interactive_1-disabled-text);
+  background-color: var(--interactive-interactive_1-background);
+  color: var(--interactive-interactive_1-text);
 }
 .interactive-interactive_2 {
-  background-color: var(--interactive-interactive_2-default-background);
-  color: var(--interactive-interactive_2-default-text);
-}
-.interactive-interactive_2:hover {
-  background-color: var(--interactive-interactive_2-hover-background);
-  color: var(--interactive-interactive_2-hover-text);
-}
-.interactive-interactive_2:active {
-  background-color: var(--interactive-interactive_2-active-background);
-  color: var(--interactive-interactive_2-active-text);
-}
-.interactive-interactive_2:disabled {
-  background-color: var(--interactive-interactive_2-disabled-background);
-  color: var(--interactive-interactive_2-disabled-text);
+  background-color: var(--interactive-interactive_2-background);
+  color: var(--interactive-interactive_2-text);
 }
 .interactive-interactive_3 {
-  background-color: var(--interactive-interactive_3-default-background);
-  color: var(--interactive-interactive_3-default-text);
-}
-.interactive-interactive_3:hover {
-  background-color: var(--interactive-interactive_3-hover-background);
-  color: var(--interactive-interactive_3-hover-text);
-}
-.interactive-interactive_3:active {
-  background-color: var(--interactive-interactive_3-active-background);
-  color: var(--interactive-interactive_3-active-text);
-}
-.interactive-interactive_3:disabled {
-  background-color: var(--interactive-interactive_3-disabled-background);
-  color: var(--interactive-interactive_3-disabled-text);
+  background-color: var(--interactive-interactive_3-background);
+  color: var(--interactive-interactive_3-text);
 }
 .interactive-interactive_destructive {
-  background-color: var(--interactive-interactive_destructive-default-background);
-  color: var(--interactive-interactive_destructive-default-text);
-}
-.interactive-interactive_destructive:hover {
-  background-color: var(--interactive-interactive_destructive-hover-background);
-  color: var(--interactive-interactive_destructive-hover-text);
-}
-.interactive-interactive_destructive:active {
-  background-color: var(--interactive-interactive_destructive-active-background);
-  color: var(--interactive-interactive_destructive-active-text);
-}
-.interactive-interactive_destructive:disabled {
-  background-color: var(--interactive-interactive_destructive-disabled-background);
-  color: var(--interactive-interactive_destructive-disabled-text);
+  background-color: var(--interactive-interactive_destructive-background);
+  color: var(--interactive-interactive_destructive-text);
 }
 
 .status-valid-primary {

--- a/packages/theme/src/themes/atb-theme/theme.module.css
+++ b/packages/theme/src/themes/atb-theme/theme.module.css
@@ -129,10 +129,10 @@
   --transport-transport_region-primary-text: #ffffff;
   --transport-transport_region-secondary-background: #006678;
   --transport-transport_region-secondary-text: #ffffff;
-  --transport-transport_airportExpress-primary-background: #a51140;
-  --transport-transport_airportExpress-primary-text: #ffffff;
-  --transport-transport_airportExpress-secondary-background: #7d0d31;
-  --transport-transport_airportExpress-secondary-text: #ffffff;
+  --transport-transport_airport_express-primary-background: #a51140;
+  --transport-transport_airport_express-primary-text: #ffffff;
+  --transport-transport_airport_express-secondary-background: #7d0d31;
+  --transport-transport_airport_express-secondary-text: #ffffff;
   --transport-transport_flexible-primary-background: #c75b12;
   --transport-transport_flexible-primary-text: #000000;
   --transport-transport_flexible-secondary-background: #97450e;
@@ -310,10 +310,10 @@
   --transport-transport_region-primary-text: #ffffff;
   --transport-transport_region-secondary-background: #006678;
   --transport-transport_region-secondary-text: #ffffff;
-  --transport-transport_airportExpress-primary-background: #a51140;
-  --transport-transport_airportExpress-primary-text: #ffffff;
-  --transport-transport_airportExpress-secondary-background: #7d0d31;
-  --transport-transport_airportExpress-secondary-text: #ffffff;
+  --transport-transport_airport_express-primary-background: #a51140;
+  --transport-transport_airport_express-primary-text: #ffffff;
+  --transport-transport_airport_express-secondary-background: #7d0d31;
+  --transport-transport_airport_express-secondary-text: #ffffff;
   --transport-transport_flexible-primary-background: #c75b12;
   --transport-transport_flexible-primary-text: #000000;
   --transport-transport_flexible-secondary-background: #97450e;
@@ -491,10 +491,10 @@
   --transport-transport_region-primary-text: #ffffff;
   --transport-transport_region-secondary-background: #006678;
   --transport-transport_region-secondary-text: #ffffff;
-  --transport-transport_airportExpress-primary-background: #a51140;
-  --transport-transport_airportExpress-primary-text: #ffffff;
-  --transport-transport_airportExpress-secondary-background: #7d0d31;
-  --transport-transport_airportExpress-secondary-text: #ffffff;
+  --transport-transport_airport_express-primary-background: #a51140;
+  --transport-transport_airport_express-primary-text: #ffffff;
+  --transport-transport_airport_express-secondary-background: #7d0d31;
+  --transport-transport_airport_express-secondary-text: #ffffff;
   --transport-transport_flexible-primary-background: #c75b12;
   --transport-transport_flexible-primary-text: #000000;
   --transport-transport_flexible-secondary-background: #97450e;
@@ -610,13 +610,13 @@
   background-color: var(--transport-transport_region-secondary-background);
   color: var(--transport-transport_region-secondary-text);
 }
-.transport-transport_airportExpress-primary {
-  background-color: var(--transport-transport_airportExpress-primary-background);
-  color: var(--transport-transport_airportExpress-primary-text);
+.transport-transport_airport_express-primary {
+  background-color: var(--transport-transport_airport_express-primary-background);
+  color: var(--transport-transport_airport_express-primary-text);
 }
-.transport-transport_airportExpress-secondary {
-  background-color: var(--transport-transport_airportExpress-secondary-background);
-  color: var(--transport-transport_airportExpress-secondary-text);
+.transport-transport_airport_express-secondary {
+  background-color: var(--transport-transport_airport_express-secondary-background);
+  color: var(--transport-transport_airport_express-secondary-text);
 }
 .transport-transport_flexible-primary {
   background-color: var(--transport-transport_flexible-primary-background);

--- a/packages/theme/tools/create-css.ts
+++ b/packages/theme/tools/create-css.ts
@@ -2,17 +2,17 @@ import outputThemes from './create-theme';
 import outputTypography from './create-typo';
 import {
   AtBThemes,
-  NfkThemes,
-  FRAMThemes,
-  TromsThemes,
-  InnlandetThemes,
+  // NfkThemes,
+  // FRAMThemes,
+  // TromsThemes,
+  // InnlandetThemes,
 } from '../src/themes';
 
 Promise.all([
   outputThemes('atb-theme', AtBThemes),
-  outputThemes('nfk-theme', NfkThemes),
-  outputThemes('fram-theme', FRAMThemes),
-  outputThemes('troms-theme', TromsThemes),
-  outputThemes('innlandet-theme', InnlandetThemes),
+  // outputThemes('nfk-theme', NfkThemes),
+  // outputThemes('fram-theme', FRAMThemes),
+  // outputThemes('troms-theme', TromsThemes),
+  // outputThemes('innlandet-theme', InnlandetThemes),
   outputTypography(),
 ]).then(() => console.log('Written CSS files'), console.error);

--- a/packages/theme/tools/fetch-figma-variables.ts
+++ b/packages/theme/tools/fetch-figma-variables.ts
@@ -9687,10 +9687,6 @@ StyleDictionary.registerTransform({
 
     const compatPath = token.path.reduce((acc, cur, index, all) => {
 
-      let lastIndex = all.findLastIndex((entry: string) => entry === cur)
-      let firstIndex = all.findIndex((entry: string) => entry === cur)
-      let origIndex = Math.abs(lastIndex - index) > Math.abs(firstIndex - index) ? firstIndex : lastIndex
-
       switch (cur) {
         case "0":
         case "1":
@@ -9711,29 +9707,34 @@ StyleDictionary.registerTransform({
         case "other":
           return acc
         case "color":
-          if (origIndex === 0) return acc
+          if (index === 0) {
+            return acc
+          }
           return acc.concat(cur)
         case "background":
-          if (origIndex === all.length - 1) {
+          if (index === all.length - 1) {
             // Unpack ContrastColor when border color
             if (all.includes("border")) {
               return acc
             }
             else return acc.concat(cur)
           }
+          
           return acc.concat("static", "background")
         case "neutral":
-          return acc.concat(`background_${all[origIndex + 1]}`)
+          return acc.concat(`background_${all[index + 1]}`)
         case "accent":
-          return acc.concat(`background_accent_${all[origIndex + 1]}`)
+          return acc.concat(`background_accent_${all[index + 1]}`)
         case "interactive":
         case "transport":
-          return acc.concat(cur, `${cur}_${all[origIndex + 1]}`)
+          return acc.concat(cur, `${cur}_${all[index + 1]}`)
         case "foreground":
           return acc.concat("text")
         case "primary":
           // If ContrastColor
-          if (origIndex === all.length - 1 && all[origIndex - 1] === "foreground" && cur === "primary") return acc
+          if (index === all.length - 1 && all[index - 1] === "foreground" && cur === "primary") {
+            return acc
+          } 
 
           return acc.concat(cur)
         case "dynamic":

--- a/packages/theme/tools/fetch-figma-variables.ts
+++ b/packages/theme/tools/fetch-figma-variables.ts
@@ -7,7 +7,7 @@ import type { Config, DesignTokens, TransformedToken } from 'style-dictionary/ty
 import { fileHeader } from 'style-dictionary/utils';
 
 import path from 'path';
-import { convertToCamelCase } from "./utils";
+import { convertToCamelCase, convertToSnakeCase } from "./utils";
 import { ThemeOptions } from "../src";
 
 /**
@@ -9727,7 +9727,8 @@ StyleDictionary.registerTransform({
           return acc.concat(`background_accent_${all[index + 1]}`)
         case "interactive":
         case "transport":
-          return acc.concat(cur, `${cur}_${all[index + 1]}`)
+          let mode = convertToSnakeCase(all[index + 1])
+          return acc.concat(cur, `${cur}_${mode}`)
         case "foreground":
           return acc.concat("text")
         case "primary":

--- a/packages/theme/tools/utils.ts
+++ b/packages/theme/tools/utils.ts
@@ -23,3 +23,7 @@ export const __dirname = dirname(fileURLToPath(import.meta.url))
 export function convertToCamelCase(input: string) {
   return input.length === 0 ? '' : input.charAt(0).toLowerCase() + input.slice(1);
 } 
+
+export function convertToSnakeCase(input: string) {
+  return input.replace(/[A-Z]/g, letter => `_${letter.toLowerCase()}`);
+} 


### PR DESCRIPTION
Since we do not wish to make a lot of changes to our (web) apps initially, I added a compatibility mode that transforms the new variable structure to the old variable structure, whilst maintaining the direct updates we get from Figma. 

## Breaking changes
_From the structure compared to version 10.x of `@atb-as/theme`_

**Removed**
- Removed `textColors` object in favor of `text` key in `Theme`;
- Removed ` baseColors` object. These are not to be used directly, but accessible through `Theme`;
- Removed `colors` object;
- Removed `backgrounds` object;
- - Removed transport color `‎transport_airport` and `‎transport_plane`.

**Changed**
- `geofencingZones` children are now lowercase instead of capitalized: `allowed`, `slow`, `noParking` and `noEntry`.

**Added**
- `ThemeOptions` added to `createThemeFor(variant, options)`, with a feature flag `useFigmaStructure`, which can be used to retrieve the new Figma structure instead of the original structure.