### PR TITLE
feat: Added `data-theme` attribute to manage themes

### DIFF
--- a/packages/theme/README.md
+++ b/packages/theme/README.md
@@ -22,10 +22,10 @@ console.log(themes.light.colors.background_0);
 ### Usage CSS
 
 > ⚠️ We're currently transitioning to a new variable structure.
-> Importing CSS from `../theme-fs/..` applies variables to `:root`.
+> Importing CSS from `../theme-fs/..` applies variables to `data-theme["auto"]`.
 > The theme follows the device preference.
 >
-> This behaviour can be overwritten by explicitly setting `.light` or `.dark`
+> This behaviour can be overwritten by explicitly setting `data-theme["light"]` or `data-theme["dark"]`
 > on an element. All children will follow that specific theme.
 
 Or you could import CSS files or as CSS Modules. The actual content is currently the same, but named differently to be imported by CSS modules.

--- a/packages/theme/src/generated/themes-fs/atb-theme/dark.css
+++ b/packages/theme/src/generated/themes-fs/atb-theme/dark.css
@@ -2,8 +2,8 @@
  * Do not edit directly, this file was auto-generated.
  */
 
-.dark, :root { color-scheme: dark; } 
-.dark, :root {
+:root[data-theme="dark"], :root[data-theme="auto"] { color-scheme: dark; } 
+:root[data-theme="dark"], :root[data-theme="auto"] {
   --color-foreground-light-primary: #ffffff;
   --color-foreground-light-secondary: #e1e7eb;
   --color-foreground-light-disabled: #a9aeb1;

--- a/packages/theme/src/generated/themes-fs/atb-theme/dark.css
+++ b/packages/theme/src/generated/themes-fs/atb-theme/dark.css
@@ -2,8 +2,8 @@
  * Do not edit directly, this file was auto-generated.
  */
 
-:root[data-theme="dark"], :root[data-theme="auto"] { color-scheme: dark; } 
-:root[data-theme="dark"], :root[data-theme="auto"] {
+[data-theme="dark"], [data-theme="auto"] { color-scheme: dark; } 
+[data-theme="dark"], [data-theme="auto"] {
   --color-foreground-light-primary: #ffffff;
   --color-foreground-light-secondary: #e1e7eb;
   --color-foreground-light-disabled: #a9aeb1;

--- a/packages/theme/src/generated/themes-fs/atb-theme/light.css
+++ b/packages/theme/src/generated/themes-fs/atb-theme/light.css
@@ -2,8 +2,8 @@
  * Do not edit directly, this file was auto-generated.
  */
 
-:root[data-theme="light"], :root[data-theme="auto"] { color-scheme: light; } 
-:root[data-theme="light"], :root[data-theme="auto"] {
+[data-theme="light"], [data-theme="auto"] { color-scheme: light; } 
+[data-theme="light"], [data-theme="auto"] {
   --color-foreground-light-primary: #ffffff;
   --color-foreground-light-secondary: #e1e7eb;
   --color-foreground-light-disabled: #a9aeb1;

--- a/packages/theme/src/generated/themes-fs/atb-theme/light.css
+++ b/packages/theme/src/generated/themes-fs/atb-theme/light.css
@@ -2,8 +2,8 @@
  * Do not edit directly, this file was auto-generated.
  */
 
-.light, :root { color-scheme: light; } 
-.light, :root {
+:root[data-theme="light"], :root[data-theme="auto"] { color-scheme: light; } 
+:root[data-theme="light"], :root[data-theme="auto"] {
   --color-foreground-light-primary: #ffffff;
   --color-foreground-light-secondary: #e1e7eb;
   --color-foreground-light-disabled: #a9aeb1;

--- a/packages/theme/src/generated/themes-fs/atb-theme/theme.css
+++ b/packages/theme/src/generated/themes-fs/atb-theme/theme.css
@@ -3,8 +3,8 @@
  */
 
 /* Import dark mode */
-@import url('dark.css') layer(theme.dark);
+@import url('dark.css');
 /* Import light mode */
-@import url('light.css') layer(theme.light);
+@import url('light.css');
 /* Override light mode if the user prefers the dark color scheme */
-@import url('dark.css') layer(theme.dark-override) (prefers-color-scheme: dark);
+@import url('dark.css') (prefers-color-scheme: dark);

--- a/packages/theme/src/generated/themes-fs/farte-theme/dark.css
+++ b/packages/theme/src/generated/themes-fs/farte-theme/dark.css
@@ -2,8 +2,8 @@
  * Do not edit directly, this file was auto-generated.
  */
 
-.dark, :root { color-scheme: dark; } 
-.dark, :root {
+:root[data-theme="dark"], :root[data-theme="auto"] { color-scheme: dark; } 
+:root[data-theme="dark"], :root[data-theme="auto"] {
   --color-foreground-light-primary: #ffffff;
   --color-foreground-light-secondary: #e1e7eb;
   --color-foreground-light-disabled: #a9aeb1;

--- a/packages/theme/src/generated/themes-fs/farte-theme/dark.css
+++ b/packages/theme/src/generated/themes-fs/farte-theme/dark.css
@@ -2,8 +2,8 @@
  * Do not edit directly, this file was auto-generated.
  */
 
-:root[data-theme="dark"], :root[data-theme="auto"] { color-scheme: dark; } 
-:root[data-theme="dark"], :root[data-theme="auto"] {
+[data-theme="dark"], [data-theme="auto"] { color-scheme: dark; } 
+[data-theme="dark"], [data-theme="auto"] {
   --color-foreground-light-primary: #ffffff;
   --color-foreground-light-secondary: #e1e7eb;
   --color-foreground-light-disabled: #a9aeb1;

--- a/packages/theme/src/generated/themes-fs/farte-theme/light.css
+++ b/packages/theme/src/generated/themes-fs/farte-theme/light.css
@@ -2,8 +2,8 @@
  * Do not edit directly, this file was auto-generated.
  */
 
-:root[data-theme="light"], :root[data-theme="auto"] { color-scheme: light; } 
-:root[data-theme="light"], :root[data-theme="auto"] {
+[data-theme="light"], [data-theme="auto"] { color-scheme: light; } 
+[data-theme="light"], [data-theme="auto"] {
   --color-foreground-light-primary: #ffffff;
   --color-foreground-light-secondary: #e1e7eb;
   --color-foreground-light-disabled: #a9aeb1;

--- a/packages/theme/src/generated/themes-fs/farte-theme/light.css
+++ b/packages/theme/src/generated/themes-fs/farte-theme/light.css
@@ -2,8 +2,8 @@
  * Do not edit directly, this file was auto-generated.
  */
 
-.light, :root { color-scheme: light; } 
-.light, :root {
+:root[data-theme="light"], :root[data-theme="auto"] { color-scheme: light; } 
+:root[data-theme="light"], :root[data-theme="auto"] {
   --color-foreground-light-primary: #ffffff;
   --color-foreground-light-secondary: #e1e7eb;
   --color-foreground-light-disabled: #a9aeb1;

--- a/packages/theme/src/generated/themes-fs/farte-theme/theme.css
+++ b/packages/theme/src/generated/themes-fs/farte-theme/theme.css
@@ -3,8 +3,8 @@
  */
 
 /* Import dark mode */
-@import url('dark.css') layer(theme.dark);
+@import url('dark.css');
 /* Import light mode */
-@import url('light.css') layer(theme.light);
+@import url('light.css');
 /* Override light mode if the user prefers the dark color scheme */
-@import url('dark.css') layer(theme.dark-override) (prefers-color-scheme: dark);
+@import url('dark.css') (prefers-color-scheme: dark);

--- a/packages/theme/src/generated/themes-fs/fram-theme/dark.css
+++ b/packages/theme/src/generated/themes-fs/fram-theme/dark.css
@@ -2,8 +2,8 @@
  * Do not edit directly, this file was auto-generated.
  */
 
-:root[data-theme="dark"], :root[data-theme="auto"] { color-scheme: dark; } 
-:root[data-theme="dark"], :root[data-theme="auto"] {
+[data-theme="dark"], [data-theme="auto"] { color-scheme: dark; } 
+[data-theme="dark"], [data-theme="auto"] {
   --color-foreground-light-primary: #ffffff;
   --color-foreground-light-secondary: #e6e6e6;
   --color-foreground-light-disabled: #b3b3b3;

--- a/packages/theme/src/generated/themes-fs/fram-theme/dark.css
+++ b/packages/theme/src/generated/themes-fs/fram-theme/dark.css
@@ -2,8 +2,8 @@
  * Do not edit directly, this file was auto-generated.
  */
 
-.dark, :root { color-scheme: dark; } 
-.dark, :root {
+:root[data-theme="dark"], :root[data-theme="auto"] { color-scheme: dark; } 
+:root[data-theme="dark"], :root[data-theme="auto"] {
   --color-foreground-light-primary: #ffffff;
   --color-foreground-light-secondary: #e6e6e6;
   --color-foreground-light-disabled: #b3b3b3;

--- a/packages/theme/src/generated/themes-fs/fram-theme/light.css
+++ b/packages/theme/src/generated/themes-fs/fram-theme/light.css
@@ -2,8 +2,8 @@
  * Do not edit directly, this file was auto-generated.
  */
 
-.light, :root { color-scheme: light; } 
-.light, :root {
+:root[data-theme="light"], :root[data-theme="auto"] { color-scheme: light; } 
+:root[data-theme="light"], :root[data-theme="auto"] {
   --color-foreground-light-primary: #ffffff;
   --color-foreground-light-secondary: #e6e6e6;
   --color-foreground-light-disabled: #b3b3b3;

--- a/packages/theme/src/generated/themes-fs/fram-theme/light.css
+++ b/packages/theme/src/generated/themes-fs/fram-theme/light.css
@@ -2,8 +2,8 @@
  * Do not edit directly, this file was auto-generated.
  */
 
-:root[data-theme="light"], :root[data-theme="auto"] { color-scheme: light; } 
-:root[data-theme="light"], :root[data-theme="auto"] {
+[data-theme="light"], [data-theme="auto"] { color-scheme: light; } 
+[data-theme="light"], [data-theme="auto"] {
   --color-foreground-light-primary: #ffffff;
   --color-foreground-light-secondary: #e6e6e6;
   --color-foreground-light-disabled: #b3b3b3;

--- a/packages/theme/src/generated/themes-fs/fram-theme/theme.css
+++ b/packages/theme/src/generated/themes-fs/fram-theme/theme.css
@@ -3,8 +3,8 @@
  */
 
 /* Import dark mode */
-@import url('dark.css') layer(theme.dark);
+@import url('dark.css');
 /* Import light mode */
-@import url('light.css') layer(theme.light);
+@import url('light.css');
 /* Override light mode if the user prefers the dark color scheme */
-@import url('dark.css') layer(theme.dark-override) (prefers-color-scheme: dark);
+@import url('dark.css') (prefers-color-scheme: dark);

--- a/packages/theme/src/generated/themes-fs/innlandet-theme/dark.css
+++ b/packages/theme/src/generated/themes-fs/innlandet-theme/dark.css
@@ -2,8 +2,8 @@
  * Do not edit directly, this file was auto-generated.
  */
 
-.dark, :root { color-scheme: dark; } 
-.dark, :root {
+:root[data-theme="dark"], :root[data-theme="auto"] { color-scheme: dark; } 
+:root[data-theme="dark"], :root[data-theme="auto"] {
   --color-foreground-light-primary: #ffffff;
   --color-foreground-light-secondary: #e3e5e6;
   --color-foreground-light-disabled: #a9aeb1;

--- a/packages/theme/src/generated/themes-fs/innlandet-theme/dark.css
+++ b/packages/theme/src/generated/themes-fs/innlandet-theme/dark.css
@@ -2,8 +2,8 @@
  * Do not edit directly, this file was auto-generated.
  */
 
-:root[data-theme="dark"], :root[data-theme="auto"] { color-scheme: dark; } 
-:root[data-theme="dark"], :root[data-theme="auto"] {
+[data-theme="dark"], [data-theme="auto"] { color-scheme: dark; } 
+[data-theme="dark"], [data-theme="auto"] {
   --color-foreground-light-primary: #ffffff;
   --color-foreground-light-secondary: #e3e5e6;
   --color-foreground-light-disabled: #a9aeb1;

--- a/packages/theme/src/generated/themes-fs/innlandet-theme/light.css
+++ b/packages/theme/src/generated/themes-fs/innlandet-theme/light.css
@@ -2,8 +2,8 @@
  * Do not edit directly, this file was auto-generated.
  */
 
-:root[data-theme="light"], :root[data-theme="auto"] { color-scheme: light; } 
-:root[data-theme="light"], :root[data-theme="auto"] {
+[data-theme="light"], [data-theme="auto"] { color-scheme: light; } 
+[data-theme="light"], [data-theme="auto"] {
   --color-foreground-light-primary: #ffffff;
   --color-foreground-light-secondary: #e3e5e6;
   --color-foreground-light-disabled: #a9aeb1;

--- a/packages/theme/src/generated/themes-fs/innlandet-theme/light.css
+++ b/packages/theme/src/generated/themes-fs/innlandet-theme/light.css
@@ -2,8 +2,8 @@
  * Do not edit directly, this file was auto-generated.
  */
 
-.light, :root { color-scheme: light; } 
-.light, :root {
+:root[data-theme="light"], :root[data-theme="auto"] { color-scheme: light; } 
+:root[data-theme="light"], :root[data-theme="auto"] {
   --color-foreground-light-primary: #ffffff;
   --color-foreground-light-secondary: #e3e5e6;
   --color-foreground-light-disabled: #a9aeb1;

--- a/packages/theme/src/generated/themes-fs/innlandet-theme/theme.css
+++ b/packages/theme/src/generated/themes-fs/innlandet-theme/theme.css
@@ -3,8 +3,8 @@
  */
 
 /* Import dark mode */
-@import url('dark.css') layer(theme.dark);
+@import url('dark.css');
 /* Import light mode */
-@import url('light.css') layer(theme.light);
+@import url('light.css');
 /* Override light mode if the user prefers the dark color scheme */
-@import url('dark.css') layer(theme.dark-override) (prefers-color-scheme: dark);
+@import url('dark.css') (prefers-color-scheme: dark);

--- a/packages/theme/src/generated/themes-fs/nfk-theme/dark.css
+++ b/packages/theme/src/generated/themes-fs/nfk-theme/dark.css
@@ -2,8 +2,8 @@
  * Do not edit directly, this file was auto-generated.
  */
 
-:root[data-theme="dark"], :root[data-theme="auto"] { color-scheme: dark; } 
-:root[data-theme="dark"], :root[data-theme="auto"] {
+[data-theme="dark"], [data-theme="auto"] { color-scheme: dark; } 
+[data-theme="dark"], [data-theme="auto"] {
   --color-foreground-light-primary: #ffffff;
   --color-foreground-light-secondary: #dae2e4;
   --color-foreground-light-disabled: #8fa9af;

--- a/packages/theme/src/generated/themes-fs/nfk-theme/dark.css
+++ b/packages/theme/src/generated/themes-fs/nfk-theme/dark.css
@@ -2,8 +2,8 @@
  * Do not edit directly, this file was auto-generated.
  */
 
-.dark, :root { color-scheme: dark; } 
-.dark, :root {
+:root[data-theme="dark"], :root[data-theme="auto"] { color-scheme: dark; } 
+:root[data-theme="dark"], :root[data-theme="auto"] {
   --color-foreground-light-primary: #ffffff;
   --color-foreground-light-secondary: #dae2e4;
   --color-foreground-light-disabled: #8fa9af;

--- a/packages/theme/src/generated/themes-fs/nfk-theme/light.css
+++ b/packages/theme/src/generated/themes-fs/nfk-theme/light.css
@@ -2,8 +2,8 @@
  * Do not edit directly, this file was auto-generated.
  */
 
-.light, :root { color-scheme: light; } 
-.light, :root {
+:root[data-theme="light"], :root[data-theme="auto"] { color-scheme: light; } 
+:root[data-theme="light"], :root[data-theme="auto"] {
   --color-foreground-light-primary: #ffffff;
   --color-foreground-light-secondary: #dae2e4;
   --color-foreground-light-disabled: #8fa9af;

--- a/packages/theme/src/generated/themes-fs/nfk-theme/light.css
+++ b/packages/theme/src/generated/themes-fs/nfk-theme/light.css
@@ -2,8 +2,8 @@
  * Do not edit directly, this file was auto-generated.
  */
 
-:root[data-theme="light"], :root[data-theme="auto"] { color-scheme: light; } 
-:root[data-theme="light"], :root[data-theme="auto"] {
+[data-theme="light"], [data-theme="auto"] { color-scheme: light; } 
+[data-theme="light"], [data-theme="auto"] {
   --color-foreground-light-primary: #ffffff;
   --color-foreground-light-secondary: #dae2e4;
   --color-foreground-light-disabled: #8fa9af;

--- a/packages/theme/src/generated/themes-fs/nfk-theme/theme.css
+++ b/packages/theme/src/generated/themes-fs/nfk-theme/theme.css
@@ -3,8 +3,8 @@
  */
 
 /* Import dark mode */
-@import url('dark.css') layer(theme.dark);
+@import url('dark.css');
 /* Import light mode */
-@import url('light.css') layer(theme.light);
+@import url('light.css');
 /* Override light mode if the user prefers the dark color scheme */
-@import url('dark.css') layer(theme.dark-override) (prefers-color-scheme: dark);
+@import url('dark.css') (prefers-color-scheme: dark);

--- a/packages/theme/src/generated/themes-fs/troms-theme/dark.css
+++ b/packages/theme/src/generated/themes-fs/troms-theme/dark.css
@@ -2,8 +2,8 @@
  * Do not edit directly, this file was auto-generated.
  */
 
-.dark, :root { color-scheme: dark; } 
-.dark, :root {
+:root[data-theme="dark"], :root[data-theme="auto"] { color-scheme: dark; } 
+:root[data-theme="dark"], :root[data-theme="auto"] {
   --color-foreground-light-primary: #ffffff;
   --color-foreground-light-secondary: #e3e5e6;
   --color-foreground-light-disabled: #a9aeb1;

--- a/packages/theme/src/generated/themes-fs/troms-theme/dark.css
+++ b/packages/theme/src/generated/themes-fs/troms-theme/dark.css
@@ -2,8 +2,8 @@
  * Do not edit directly, this file was auto-generated.
  */
 
-:root[data-theme="dark"], :root[data-theme="auto"] { color-scheme: dark; } 
-:root[data-theme="dark"], :root[data-theme="auto"] {
+[data-theme="dark"], [data-theme="auto"] { color-scheme: dark; } 
+[data-theme="dark"], [data-theme="auto"] {
   --color-foreground-light-primary: #ffffff;
   --color-foreground-light-secondary: #e3e5e6;
   --color-foreground-light-disabled: #a9aeb1;

--- a/packages/theme/src/generated/themes-fs/troms-theme/light.css
+++ b/packages/theme/src/generated/themes-fs/troms-theme/light.css
@@ -2,8 +2,8 @@
  * Do not edit directly, this file was auto-generated.
  */
 
-:root[data-theme="light"], :root[data-theme="auto"] { color-scheme: light; } 
-:root[data-theme="light"], :root[data-theme="auto"] {
+[data-theme="light"], [data-theme="auto"] { color-scheme: light; } 
+[data-theme="light"], [data-theme="auto"] {
   --color-foreground-light-primary: #ffffff;
   --color-foreground-light-secondary: #e3e5e6;
   --color-foreground-light-disabled: #a9aeb1;

--- a/packages/theme/src/generated/themes-fs/troms-theme/light.css
+++ b/packages/theme/src/generated/themes-fs/troms-theme/light.css
@@ -2,8 +2,8 @@
  * Do not edit directly, this file was auto-generated.
  */
 
-.light, :root { color-scheme: light; } 
-.light, :root {
+:root[data-theme="light"], :root[data-theme="auto"] { color-scheme: light; } 
+:root[data-theme="light"], :root[data-theme="auto"] {
   --color-foreground-light-primary: #ffffff;
   --color-foreground-light-secondary: #e3e5e6;
   --color-foreground-light-disabled: #a9aeb1;

--- a/packages/theme/src/generated/themes-fs/troms-theme/theme.css
+++ b/packages/theme/src/generated/themes-fs/troms-theme/theme.css
@@ -3,8 +3,8 @@
  */
 
 /* Import dark mode */
-@import url('dark.css') layer(theme.dark);
+@import url('dark.css');
 /* Import light mode */
-@import url('light.css') layer(theme.light);
+@import url('light.css');
 /* Override light mode if the user prefers the dark color scheme */
-@import url('dark.css') layer(theme.dark-override) (prefers-color-scheme: dark);
+@import url('dark.css') (prefers-color-scheme: dark);

--- a/packages/theme/src/generated/themes-fs/vkt-theme/dark.css
+++ b/packages/theme/src/generated/themes-fs/vkt-theme/dark.css
@@ -2,8 +2,8 @@
  * Do not edit directly, this file was auto-generated.
  */
 
-.dark, :root { color-scheme: dark; } 
-.dark, :root {
+:root[data-theme="dark"], :root[data-theme="auto"] { color-scheme: dark; } 
+:root[data-theme="dark"], :root[data-theme="auto"] {
   --color-foreground-light-primary: #ffffff;
   --color-foreground-light-secondary: #e1e7eb;
   --color-foreground-light-disabled: #a9aeb1;

--- a/packages/theme/src/generated/themes-fs/vkt-theme/dark.css
+++ b/packages/theme/src/generated/themes-fs/vkt-theme/dark.css
@@ -2,8 +2,8 @@
  * Do not edit directly, this file was auto-generated.
  */
 
-:root[data-theme="dark"], :root[data-theme="auto"] { color-scheme: dark; } 
-:root[data-theme="dark"], :root[data-theme="auto"] {
+[data-theme="dark"], [data-theme="auto"] { color-scheme: dark; } 
+[data-theme="dark"], [data-theme="auto"] {
   --color-foreground-light-primary: #ffffff;
   --color-foreground-light-secondary: #e1e7eb;
   --color-foreground-light-disabled: #a9aeb1;

--- a/packages/theme/src/generated/themes-fs/vkt-theme/light.css
+++ b/packages/theme/src/generated/themes-fs/vkt-theme/light.css
@@ -2,8 +2,8 @@
  * Do not edit directly, this file was auto-generated.
  */
 
-:root[data-theme="light"], :root[data-theme="auto"] { color-scheme: light; } 
-:root[data-theme="light"], :root[data-theme="auto"] {
+[data-theme="light"], [data-theme="auto"] { color-scheme: light; } 
+[data-theme="light"], [data-theme="auto"] {
   --color-foreground-light-primary: #ffffff;
   --color-foreground-light-secondary: #e1e7eb;
   --color-foreground-light-disabled: #a9aeb1;

--- a/packages/theme/src/generated/themes-fs/vkt-theme/light.css
+++ b/packages/theme/src/generated/themes-fs/vkt-theme/light.css
@@ -2,8 +2,8 @@
  * Do not edit directly, this file was auto-generated.
  */
 
-.light, :root { color-scheme: light; } 
-.light, :root {
+:root[data-theme="light"], :root[data-theme="auto"] { color-scheme: light; } 
+:root[data-theme="light"], :root[data-theme="auto"] {
   --color-foreground-light-primary: #ffffff;
   --color-foreground-light-secondary: #e1e7eb;
   --color-foreground-light-disabled: #a9aeb1;

--- a/packages/theme/src/generated/themes-fs/vkt-theme/theme.css
+++ b/packages/theme/src/generated/themes-fs/vkt-theme/theme.css
@@ -3,8 +3,8 @@
  */
 
 /* Import dark mode */
-@import url('dark.css') layer(theme.dark);
+@import url('dark.css');
 /* Import light mode */
-@import url('light.css') layer(theme.light);
+@import url('light.css');
 /* Override light mode if the user prefers the dark color scheme */
-@import url('dark.css') layer(theme.dark-override) (prefers-color-scheme: dark);
+@import url('dark.css') (prefers-color-scheme: dark);

--- a/packages/theme/tools/fetch-figma-variables.ts
+++ b/packages/theme/tools/fetch-figma-variables.ts
@@ -199,11 +199,11 @@ export default themes`;
  * Contents of the main CSS file linking the themes
  */
 const cssIndex = `/* Import dark mode */
-@import url('dark.css') layer(theme.dark);
+@import url('dark.css');
 /* Import light mode */
-@import url('light.css') layer(theme.light);
+@import url('light.css');
 /* Override light mode if the user prefers the dark color scheme */
-@import url('dark.css') layer(theme.dark-override) (prefers-color-scheme: dark);
+@import url('dark.css') (prefers-color-scheme: dark);
 `;
 
 /**
@@ -348,7 +348,7 @@ const generateThemes = async () => {
             {
               format: 'css/variables',
               options: {
-                selector: `.${mode}, :root { color-scheme: ${mode}; } \n.${mode}, :root`,
+                selector: `:root[data-theme="${mode}"], :root[data-theme="auto"] { color-scheme: ${mode}; } \n:root[data-theme="${mode}"], :root[data-theme="auto"]`,
               },
               destination: `${mode}.css`,
               filter: 'filter-palette',

--- a/packages/theme/tools/fetch-figma-variables.ts
+++ b/packages/theme/tools/fetch-figma-variables.ts
@@ -348,7 +348,7 @@ const generateThemes = async () => {
             {
               format: 'css/variables',
               options: {
-                selector: `:root[data-theme="${mode}"], :root[data-theme="auto"] { color-scheme: ${mode}; } \n:root[data-theme="${mode}"], :root[data-theme="auto"]`,
+                selector: `[data-theme="${mode}"], [data-theme="auto"] { color-scheme: ${mode}; } \n[data-theme="${mode}"], [data-theme="auto"]`,
               },
               destination: `${mode}.css`,
               filter: 'filter-palette',


### PR DESCRIPTION
In the generated CSS files, we used the follow syntax

```
@import URL layer(LAYER_NAME) (MEDIA_QUERY)
```

However, NextJS seems to have trouble with this syntax without relying on external plugins such as `postcss-import` (see https://github.com/vercel/next.js/issues/55763 for more info).

Therefore, we are getting rid of the layers, which means that we need a more specific selector to define the current theme. Without layers, :root with a media query would always take precedence over class names (e.g. `.light`). This solution remedies that and has been tested in `webshop2`