### PR TITLE
feat: Added brand color tokens to Theme type

### DIFF
--- a/packages/theme/src/theme.ts
+++ b/packages/theme/src/theme.ts
@@ -116,6 +116,11 @@ export interface Theme {
       error: StatusColor<ContrastColor>;
     };
 
+    brand: {
+      primary: ContrastColor;
+      secondary: ContrastColor;
+    };
+
     background: {
       neutral: {
         0: ContrastColor;


### PR DESCRIPTION
We added brand color tokens in Figma, but now they need to be accessible through the Theme type before we can use them