### PR TITLE
fix: lock `@atb-as/theme` to v14.0.1

### DIFF
--- a/packages/assets/package.json
+++ b/packages/assets/package.json
@@ -29,7 +29,7 @@
     "access": "public"
   },
   "dependencies": {
-    "@atb-as/theme": "^14.0.1",
+    "@atb-as/theme": "14.0.1",
     "commander": "^9.4.0",
     "fast-glob": "^3.2.11",
     "micromatch": "^4.0.5",


### PR DESCRIPTION
It's silly that this could break the build, but here we are 🫠 I'm more and more in favor of scrapping this whole monorepo thing.