### PR TITLE
build: add module es2020

### DIFF
--- a/packages/theme/tools/create-typo.ts
+++ b/packages/theme/tools/create-typo.ts
@@ -1,5 +1,6 @@
 import {writeFile} from 'fs/promises';
-import {join} from 'path';
+import {fileURLToPath} from 'url';
+import {join, dirname} from 'path';
 import {
   createTextTypeStyles,
   FontBook,
@@ -10,6 +11,8 @@ import {
 } from '../src/typography';
 import {indentLine, maybeConvertToRem} from './utils';
 
+const __filename = fileURLToPath(import.meta.url);
+const __dirname = dirname(__filename);
 const base = join(__dirname, '../src/generated');
 const cssModule = join(base, 'typography.module.css');
 const regular = join(base, 'typography.css');

--- a/packages/theme/tsconfig.build.json
+++ b/packages/theme/tsconfig.build.json
@@ -3,7 +3,8 @@
   "compilerOptions": {
     "declaration": true,
     "outDir": "./lib/",
-    "noEmit": false
+    "noEmit": false,
+    "module": "es2020"
   },
   "exclude": ["node_modules", "lib", "tools"],
   "include": ["src"]

--- a/packages/theme/tsconfig.json
+++ b/packages/theme/tsconfig.json
@@ -2,7 +2,8 @@
   "extends": "../../tsconfig.json",
   "compilerOptions": {
     "declaration": true,
-    "noEmit": true
+    "noEmit": true,
+    "module": "es2020"
   },
   "exclude": ["node_modules", "lib"],
   "include": ["src", "tools"]


### PR DESCRIPTION
Attempt to fix the issue encountered here:
https://github.com/AtB-AS/design-system/actions/runs/17293053518/job/49084692347
```
/home/runner/work/design-system/design-system/packages/theme/tools/create-typo.ts:13
const base = join(__dirname, '../src/generated');
                  ^
ReferenceError: __dirname is not defined in ES module scope
```