### PR TITLE
fix: match `.*` when filtering files with micromatch

### DIFF
--- a/packages/assets/src/generate.ts
+++ b/packages/assets/src/generate.ts
@@ -74,7 +74,7 @@ export async function generateAssets(
   log('Found merged files:', allFilesToBeCopied.length);
 
   const potentiallyFiltered = opts.patterns
-    ? micromatch(allFilesToBeCopied, opts.patterns)
+    ? micromatch(allFilesToBeCopied, opts.patterns, {dot: true})
     : allFilesToBeCopied;
 
   let allFiles = potentiallyFiltered.map(async (absolutePath) => {


### PR DESCRIPTION
Without this option set, no files where found when using pnpm, since they are installed to `node_modules/.pnpm/`. micromatch ignores any "hidden" files or folders by default.

https://github.com/micromatch/micromatch#options

Part of https://github.com/AtB-AS/kundevendt/issues/23887